### PR TITLE
Fixes some import/setup order bugs and potential bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ task prefect -- deployment run "Download a study read-runs/realistic_example_dep
 * Use type hinting: `def my_func(param: List[str]) -> int:`
 * Prefer to use `pathlib` instead of `os.path`, e.g. for joining parts: `Path("/nfs/my/dir") / "subdir" / "file.txt"`
 * Config parameters (like the URL for ENA etc.) should use structured [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/). See `settings.EMG_CONFIG`.
+* `EMG_CONFIG` should [always be imported via `django.conf.settings`](https://docs.djangoproject.com/en/5.1/topics/settings/#using-settings-in-python-code): e.g. `from django.conf import settings; EMG_CONFIG = settings.EMG_CONFIG`
 * When you have a list of acceptable options for something, use `Enum`s or `TextChoices` (a kind of enum for Django db fields): `class AssemblyStatuses(str, Enum):...`
 * Use Django/postgres JSONFields liberally (they can save a load of complicated JOINs)
 * Apply a schema to JSONFields, using Enums, default dicts, custom pydantic types... see `WithDownloadsModel` for an example

--- a/analyses/schemas.py
+++ b/analyses/schemas.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 from enum import Enum
 from typing import List, Optional, Union
 
+from django.conf import settings
 from ninja import Field, ModelSchema, Schema
 from typing_extensions import Annotated
 
 import analyses.models
 from analyses.base_models.with_downloads_models import DownloadFile
-from emgapiv2.settings import EMG_CONFIG
+
+EMG_CONFIG = settings.EMG_CONFIG
 
 
 class MGnifyStudy(ModelSchema):

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -1,17 +1,19 @@
 from typing import List
 
 import httpx
+from django.conf import settings
 from prefect import get_run_logger, task
 
 import analyses.models
 import ena.models
-from emgapiv2.settings import EMG_CONFIG
 from workflows.prefect_utils.cache_control import context_agnostic_task_input_hash
 
 ALLOWED_LIBRARY_SOURCE: list = ["METAGENOMIC", "METATRANSCRIPTOMIC"]
 SINGLE_END_LIBRARY_LAYOUT: str = "SINGLE"
 PAIRED_END_LIBRARY_LAYOUT: str = "PAIRED"
 METAGENOME_SCIENTIFIC_NAME: str = "metagenome"
+
+EMG_CONFIG = settings.EMG_CONFIG
 
 
 def create_ena_api_request(result_type, query, limit, fields, result_format="json"):

--- a/workflows/ena_utils/ena_file_fetching.py
+++ b/workflows/ena_utils/ena_file_fetching.py
@@ -1,6 +1,8 @@
 import logging
 
-from emgapiv2.settings import EMG_CONFIG
+from django.conf import settings
+
+EMG_CONFIG = settings.EMG_CONFIG
 
 
 def convert_ena_ftp_to_fire_fastq(

--- a/workflows/flows/analysis_amplicon_study.py
+++ b/workflows/flows/analysis_amplicon_study.py
@@ -9,7 +9,6 @@ import django
 import pandas as pd
 from django.db.models import QuerySet
 
-from emgapiv2.settings import EMG_CONFIG
 from workflows.data_io_utils.csv.csv_comment_handler import (
     CSVDelimiter,
     move_file_pointer_past_comment_lines,

--- a/workflows/flows/upload_assembly.py
+++ b/workflows/flows/upload_assembly.py
@@ -8,6 +8,7 @@ from typing import Optional
 import django
 from assembly_uploader import assembly_manifest, study_xmls, submit_study
 from Bio import SeqIO
+from django.conf import settings
 
 from workflows.prefect_utils.env_context import TemporaryEnv
 
@@ -19,13 +20,14 @@ from prefect.task_runners import SequentialTaskRunner
 
 import analyses.models
 import ena.models
-from emgapiv2.settings import EMG_CONFIG
 from workflows.prefect_utils.analyses_models_helpers import task_mark_assembly_status
 from workflows.prefect_utils.cache_control import context_agnostic_task_input_hash
 from workflows.prefect_utils.slurm_flow import (
     ClusterJobFailedException,
     run_cluster_job,
 )
+
+EMG_CONFIG = settings.EMG_CONFIG
 
 OPTIONAL_SPADES_FILES = [
     ".assembly_graph.fastg.gz",

--- a/workflows/nextflow_utils/samplesheets.py
+++ b/workflows/nextflow_utils/samplesheets.py
@@ -7,11 +7,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
+from django.conf import settings
 from django.db.models import QuerySet
 from prefect.client.schemas import FlowRun
 from prefect.deployments import run_deployment
 
-from emgapiv2.settings import EMG_CONFIG
+EMG_CONFIG = settings.EMG_CONFIG
 
 logger = logging.getLogger(__name__)
 

--- a/workflows/prefect_utils/slurm_flow.py
+++ b/workflows/prefect_utils/slurm_flow.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from textwrap import dedent as _
 from typing import Callable, List, Optional, Union
 
+from django.conf import settings
 from django.utils.text import slugify
 from prefect import Flow, State, flow, get_run_logger, task
 from prefect.artifacts import create_markdown_artifact, create_table_artifact
@@ -21,7 +22,6 @@ from pydantic import AnyUrl
 from pydantic_core import Url
 
 from emgapiv2.log_utils import mask_sensitive_data as safe
-from emgapiv2.settings import EMG_CONFIG
 from workflows.data_io_utils.filenames import file_path_shortener
 from workflows.prefect_utils.cache_control import context_agnostic_task_input_hash
 
@@ -35,6 +35,7 @@ else:
         logging.warning("No PySlurm available. Patching.")
         import workflows.prefect_utils.pyslurm_patch as pyslurm
 
+EMG_CONFIG = settings.EMG_CONFIG
 
 CLUSTER_WORKPOOL = "slurm"
 SLURM_JOB_ID = "Slurm Job ID"

--- a/workflows/tests/test_analysis_amplicon_study_flow.py
+++ b/workflows/tests/test_analysis_amplicon_study_flow.py
@@ -5,12 +5,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from django.conf import settings
 from django.db.models import Q
 from prefect.artifacts import Artifact
 
 import analyses.models
-from emgapiv2.settings import EMG_CONFIG
 from workflows.flows.analysis_amplicon_study import analysis_amplicon_study
+
+EMG_CONFIG = settings.EMG_CONFIG
 
 
 def generate_fake_pipeline_all_results(amplicon_run_folder, run):

--- a/workflows/tests/test_assemble_study_flow.py
+++ b/workflows/tests/test_assemble_study_flow.py
@@ -4,14 +4,16 @@ import shutil
 from enum import Enum
 
 import pytest
+from django.conf import settings
 from prefect.artifacts import Artifact
 from pydantic import BaseModel
 
 import analyses.models
 import ena.models
-from emgapiv2.settings import EMG_CONFIG
 from workflows.flows.assemble_study import AssemblerChoices, assemble_study
 from workflows.prefect_utils.analyses_models_helpers import task_mark_assembly_status
+
+EMG_CONFIG = settings.EMG_CONFIG
 
 
 @pytest.mark.django_db(transaction=True)

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -1,13 +1,15 @@
 import pytest
+from django.conf import settings
 from prefect.logging import disable_run_logger
 
 import analyses.models
 import ena.models
-from emgapiv2.settings import EMG_CONFIG
 from workflows.ena_utils.ena_api_requests import (
     get_study_from_ena,
     get_study_readruns_from_ena,
 )
+
+EMG_CONFIG = settings.EMG_CONFIG
 
 
 @pytest.mark.django_db(transaction=True)

--- a/workflows/tests/test_samplesheet_editor.py
+++ b/workflows/tests/test_samplesheet_editor.py
@@ -4,15 +4,17 @@ from unittest.mock import patch
 from urllib.parse import quote
 
 import pytest
+from django.conf import settings
 from django.http import Http404
 from django.urls import reverse
 
-from emgapiv2.settings import EMG_CONFIG
 from workflows.nextflow_utils.samplesheets import (
     location_for_samplesheet_to_be_edited,
     location_where_samplesheet_was_edited,
 )
 from workflows.views import encode_samplesheet_path, validate_samplesheet_path
+
+EMG_CONFIG = settings.EMG_CONFIG
 
 
 def test_samplesheet_editor_paths_validation(settings):

--- a/workflows/views.py
+++ b/workflows/views.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from urllib.parse import quote, unquote
 
 from asgiref.sync import async_to_sync
+from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404
 from django.shortcuts import redirect, render
@@ -16,7 +17,6 @@ from prefect.exceptions import FlowRunWaitTimeout, ObjectNotFound
 from prefect.flow_runs import wait_for_flow_run
 from unfold.sites import UnfoldAdminSite
 
-from emgapiv2.settings import EMG_CONFIG
 from workflows.nextflow_utils.samplesheets import (
     location_for_samplesheet_to_be_edited,
     location_where_samplesheet_was_edited,
@@ -25,6 +25,7 @@ from workflows.nextflow_utils.samplesheets import (
 )
 
 logger = logging.getLogger(__name__)
+EMG_CONFIG = settings.EMG_CONFIG
 
 
 def encode_samplesheet_path(filepath: str | Path) -> str:


### PR DESCRIPTION
This PR:
- fixes a bug that was blocking assembly flow from running when not in an already initialized django env (i.e. everywhere other than in the unit tests)
  - this was caused by an import order problem where models were imported before `django.setup()`. I couldn't quickly think of a way to routinely test or lint this, but we should either develop a check for it or some better base pattern for flows to prevent it.
- makes sure `EMG_CONFIG` is always fetched via the proper django settings method, since that could also be a source of strange not-correctly-initialised bugs 