### PR TITLE
Adds/reconciles config params for amplicon+assembler pipeline memory and time requirements

### DIFF
--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -34,12 +34,6 @@ class SlurmConfig(BaseModel):
 
     datamover_paritition: str = "datamover"
 
-    assembly_uploader_python_executable: str = "python3"
-    assembly_uploader_root_dir: str = ""
-    webin_cli_executor: str = "/usr/bin/webin-cli/webin-cli.jar"
-
-    amplicon_nextflow_master_job_memory: int = 1  # Gb
-
     shared_filesystem_root_on_slurm: str = "/nfs/public"
     shared_filesystem_root_on_server: str = "/app/data"
 
@@ -56,6 +50,11 @@ class AssemblerConfig(BaseModel):
         "main"  # branch or commit of ebi-metagenomics/miassembler
     )
     miassembler_nf_profile: str = "codon_slurm"
+    assembly_pipeline_time_limit_days: int = 5
+    assembly_nextflow_master_job_memory_gb: int = 8
+
+    assembly_uploader_mem_gb: int = 4
+    assembly_uploader_time_limit_hrs: int = 2
 
 
 class AmpliconPipelineConfig(BaseModel):
@@ -76,6 +75,9 @@ class AmpliconPipelineConfig(BaseModel):
     asv_folder: str = "asv"
     primer_identification_folder: str = "primer-identification"
     taxonomy_summary_folder: str = "taxonomy-summary"
+
+    amplicon_nextflow_master_job_memory_gb: int = 1
+    amplicon_pipeline_time_limit_days: int = 5
 
 
 class WebinConfig(BaseModel):

--- a/workflows/flows/analysis_amplicon_study.py
+++ b/workflows/flows/analysis_amplicon_study.py
@@ -651,8 +651,10 @@ async def perform_amplicons_in_parallel(
         await run_cluster_job(
             name=f"Analyse amplicon study {mgnify_study.ena_study.accession} via samplesheet {slugify(samplesheet)}",
             command=command,
-            expected_time=timedelta(days=5),
-            memory=f"{EMG_CONFIG.slurm.amplicon_nextflow_master_job_memory}G",
+            expected_time=timedelta(
+                days=EMG_CONFIG.amplicon_pipeline.amplicon_pipeline_time_limit_days
+            ),
+            memory=f"{EMG_CONFIG.amplicon_pipeline.amplicon_nextflow_master_job_memory_gb}G",
             environment=env_variables,
             input_files_to_hash=[samplesheet],
         )

--- a/workflows/flows/assemble_study.py
+++ b/workflows/flows/assemble_study.py
@@ -288,7 +288,6 @@ async def run_assembler_for_samplesheet(
     mgnify_study: analyses.models.Study,
     samplesheet_csv: Path,
     assembler: analyses.models.Assembler,
-    memory_gb_for_head_job: int = 8,
 ):
     samplesheet_df = pd.read_csv(samplesheet_csv, sep=",")
     assemblies: list[analyses.models.Assembly] = mgnify_study.assemblies_reads.filter(
@@ -322,8 +321,10 @@ async def run_assembler_for_samplesheet(
         await run_cluster_job(
             name=f"Assemble study {mgnify_study.ena_study.accession} via samplesheet {file_path_shortener(samplesheet_csv, 1, 15, True)}",
             command=command,
-            expected_time=timedelta(days=5),
-            memory=f"{memory_gb_for_head_job}G",
+            expected_time=timedelta(
+                days=EMG_CONFIG.assembler.assembly_pipeline_time_limit_days
+            ),
+            memory=f"{EMG_CONFIG.assembler.assembly_nextflow_master_job_memory_gb}G",
             environment="ALL,TOWER_ACCESS_TOKEN,TOWER_WORKSPACE_ID",
             input_files_to_hash=[samplesheet_csv],
         )

--- a/workflows/flows/upload_assembly.py
+++ b/workflows/flows/upload_assembly.py
@@ -357,8 +357,10 @@ async def submit_assembly_slurm(
         await run_cluster_job(
             name=f"Upload assembly for {mgnify_assembly} to ENA",
             command=command,
-            expected_time=timedelta(hours=1),
-            memory=f"4G",
+            expected_time=timedelta(
+                hours=EMG_CONFIG.assembler.assembly_uploader_time_limit_hrs
+            ),
+            memory=f"{EMG_CONFIG.assembler.assembly_uploader_mem_gb}G",
             environment="ALL",  # copy env vars from the prefect agent into the slurm job
             input_files_to_hash=[manifest],
         )


### PR DESCRIPTION
Assembly uploader now has 2hrs slurm time limit by default, but moved to config so can be overridden by env vars. A bit of other config cleanup at the same time.