### PR TITLE
Python3.10 / 3.11 enum compataibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ It will ask you for a password, which is for a django admin user called `emgdev`
 
 #### Set up a couple of common flows for example
 ```shell
-task prefect -- block register -m prefect_slack.credentials  # this enables a prefect -> slack notification system
 FLOW=realistic_example task deploy-flow  # this "deploys" workflows/flows/realistic_example.py:realistic_example to your local prefect server
 # This flow is just a minimal demo to show how the prefect+django integration works.
 
@@ -136,7 +135,7 @@ task prefect -- deployment run "Download a study read-runs/realistic_example_dep
 * Prefer to use `pathlib` instead of `os.path`, e.g. for joining parts: `Path("/nfs/my/dir") / "subdir" / "file.txt"`
 * Config parameters (like the URL for ENA etc.) should use structured [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/). See `settings.EMG_CONFIG`.
 * `EMG_CONFIG` should [always be imported via `django.conf.settings`](https://docs.djangoproject.com/en/5.1/topics/settings/#using-settings-in-python-code): e.g. `from django.conf import settings; EMG_CONFIG = settings.EMG_CONFIG`
-* When you have a list of acceptable options for something, use `Enum`s or `TextChoices` (a kind of enum for Django db fields): `class AssemblyStatuses(str, Enum):...`
+* When you have a list of acceptable options for something, use `Enum`s or `TextChoices` (a kind of enum for Django db fields): `class AssemblyStatuses(FutureStrEnum):...` or `DjangoChoicesCompatibleStrEnum` if it is used both as a general `Enum` and as `choice=` parameter of a Django field.
 * Use Django/postgres JSONFields liberally (they can save a load of complicated JOINs)
 * Apply a schema to JSONFields, using Enums, default dicts, custom pydantic types... see `WithDownloadsModel` for an example
 * Use class mixins and Django abstract models liberally, to add shared/similar functionality to multiple models

--- a/analyses/base_models/with_downloads_models.py
+++ b/analyses/base_models/with_downloads_models.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
-from enum import Enum
 from pathlib import Path
 from typing import List, Optional, Union
 
 from django.db import models
 from pydantic import BaseModel, field_validator
 
+from emgapiv2.enum_utils import FutureStrEnum
 
-class DownloadType(str, Enum):
+
+class DownloadType(FutureStrEnum):
     SEQUENCE_DATA = "Sequence data"
     FUNCTIONAL_ANALYSIS = "Functional analysis"
     TAXONOMIC_ANALYSIS = "Taxonomic analysis"
@@ -19,7 +20,7 @@ class DownloadType(str, Enum):
     OTHER = "Other"
 
 
-class DownloadFileType(str, Enum):
+class DownloadFileType(FutureStrEnum):
     FASTA = "fasta"
     TSV = "tsv"
     BIOM = "biom"

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -497,7 +497,7 @@ class Analysis(
 
     TAXONOMIES = "taxonomies"
 
-    class TaxonomySources(Enum):
+    class TaxonomySources(FutureStrEnum):
         SSU: str = "ssu"
         LSU: str = "lsu"
         ITS_ONE_DB: str = "its_one_db"

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -28,6 +28,7 @@ from analyses.base_models.mgnify_accessioned_models import MGnifyAccessionField
 from analyses.base_models.with_downloads_models import WithDownloadsModel
 from analyses.base_models.with_status_models import SelectByStatusManagerMixin
 from emgapiv2.async_utils import anysync_property
+from emgapiv2.enum_utils import FutureStrEnum
 
 # Some models associated with MGnify Analyses (MGYS, MGYA etc).
 
@@ -263,7 +264,7 @@ class Assembly(TimeStampedModel, ENADerivedModel):
 
     metadata = JSONField(default=dict, db_index=True, blank=True)
 
-    class AssemblyStates(str, Enum):
+    class AssemblyStates(FutureStrEnum):
         ENA_METADATA_SANITY_CHECK_FAILED = "ena_metadata_sanity_check_failed"
         ENA_DATA_QC_CHECK_FAILED = "ena_data_qc_check_failed"
         ASSEMBLY_STARTED = "assembly_started"
@@ -538,7 +539,7 @@ class Analysis(
         choices=PipelineVersions, max_length=5, default=PipelineVersions.v6
     )
 
-    class AnalysisStates(str, Enum):
+    class AnalysisStates(FutureStrEnum):
         ANALYSIS_STARTED = "analysis_started"
         ANALYSIS_COMPLETED = "analysis_completed"
         ANALYSIS_BLOCKED = "analysis_blocked"

--- a/analyses/schemas.py
+++ b/analyses/schemas.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import List, Optional, Union
 
 from django.conf import settings
@@ -9,6 +8,7 @@ from typing_extensions import Annotated
 
 import analyses.models
 from analyses.base_models.with_downloads_models import DownloadFile
+from emgapiv2.enum_utils import FutureStrEnum
 
 EMG_CONFIG = settings.EMG_CONFIG
 
@@ -170,7 +170,7 @@ class MGnifyAssemblyAnalysisRequest(ModelSchema):
         fields = ["requestor", "status", "study", "request_metadata", "id"]
 
 
-class MGnifyFunctionalAnalysisAnnotationType(Enum):
+class MGnifyFunctionalAnalysisAnnotationType(FutureStrEnum):
     genome_properties: str = analyses.models.Analysis.GENOME_PROPERTIES
     go_terms: str = analyses.models.Analysis.GO_TERMS
     go_slims: str = analyses.models.Analysis.GO_SLIMS

--- a/emgapiv2/enum_utils.py
+++ b/emgapiv2/enum_utils.py
@@ -1,7 +1,18 @@
-from enum import Enum
+import enum
+
+from django.utils.version import PY311
+
+# Define StrEnum for Python3.10, to work like 3.11+
+if PY311:  # or later
+    FutureStrEnum = enum.StrEnum
+else:
+
+    class FutureStrEnum(str, enum.Enum):
+        def __str__(self):
+            return str(self.value)
 
 
-class DjangoChoicesCompatibleStrEnum(str, Enum):
+class DjangoChoicesCompatibleStrEnum(FutureStrEnum):
     # TODO: after python 3.11 adopted everywhere switch str, Enum -> StrEnum
     """
     This is a str Enum that can also be easily converted to a Django Choices object.

--- a/emgapiv2/schema_utils.py
+++ b/emgapiv2/schema_utils.py
@@ -1,14 +1,16 @@
 from enum import Enum
 
+from emgapiv2.enum_utils import FutureStrEnum
 
-class ApiSections(Enum):
+
+class ApiSections(FutureStrEnum):
     STUDIES = "Studies"
     SAMPLES = "Samples"
     ANALYSES = "Analyses"
     REQUESTS = "Requests"
 
 
-class OpenApiKeywords(Enum):
+class OpenApiKeywords(FutureStrEnum):
     NAME = "name"
     DESCRIPTION = "description"
     RESPONSES = "responses"

--- a/emgapiv2/test_utils.py
+++ b/emgapiv2/test_utils.py
@@ -120,5 +120,5 @@ def test_enum_stringification():
         HELLO = "hello"
         WORLD = "world"
 
-    assert str(MyEnum.HELLO) == "hello"  # default in py3.10 would be MyEnum.HELLO
+    assert str(MyEnum.HELLO) == "hello"
     assert str(MyEnum.HELLO.value) == "hello"

--- a/emgapiv2/test_utils.py
+++ b/emgapiv2/test_utils.py
@@ -4,6 +4,7 @@ from django.db import models
 from pydantic import BaseModel
 
 from emgapiv2.async_utils import anysync_property
+from emgapiv2.enum_utils import FutureStrEnum
 from emgapiv2.log_utils import mask_sensitive_data
 from emgapiv2.model_utils import JSONFieldWithSchema
 
@@ -112,3 +113,12 @@ def test_json_field_with_schema():
 
     instance = TestModel2(my_data=[single_datum])
     assert TestSchema.model_validate(instance.my_data[0]).name == "X-wing"
+
+
+def test_enum_stringification():
+    class MyEnum(FutureStrEnum):
+        HELLO = "hello"
+        WORLD = "world"
+
+    assert str(MyEnum.HELLO) == "hello"  # default in py3.10 would be MyEnum.HELLO
+    assert str(MyEnum.HELLO.value) == "hello"

--- a/workflows/data_io_utils/csv/csv_comment_handler.py
+++ b/workflows/data_io_utils/csv/csv_comment_handler.py
@@ -1,5 +1,6 @@
 import csv
-from enum import Enum
+
+from emgapiv2.enum_utils import FutureStrEnum
 
 
 def move_file_pointer_past_comment_lines(
@@ -53,7 +54,7 @@ def move_file_pointer_past_comment_lines(
         f.seek(pos)
 
 
-class CSVDelimiter(str, Enum):
+class CSVDelimiter(FutureStrEnum):
     COMMA = ","
     TAB = "\t"
 

--- a/workflows/flows/assemble_study.py
+++ b/workflows/flows/assemble_study.py
@@ -8,6 +8,8 @@ from prefect import flow, get_run_logger, suspend_flow_run
 from prefect.input import RunInput
 from prefect.task_runners import SequentialTaskRunner
 
+from emgapiv2.enum_utils import FutureStrEnum
+
 django.setup()
 
 import analyses.models
@@ -31,7 +33,7 @@ from workflows.prefect_utils.slack_notification import notify_via_slack
 EMG_CONFIG = settings.EMG_CONFIG
 
 
-class AssemblerChoices(str, Enum):
+class AssemblerChoices(FutureStrEnum):
     # IDEA: it would be nice to sniff this from the pipeline schema
     pipeline_default = "pipeline_default"
     megahit = "megahit"


### PR DESCRIPTION
This PR fixes some bugs due to different strinigication of enums between python 3.11 (used in production), and 3.10 (used in development/testing). The version different is due to wishing to keep production fairly up to date, but the dev env is limited to 3.10 by the available packages whilst easily installing slurm-wlm.

Python 3.11 introduces a change to `Enum.__str__`, (`MyEnum.MY_FIELD` instead of `my_field`), but added `enum.StrEnum` to work like `MyEnum(str, Enum)` used to work. This PR lets python3.10 use something like `StrEnum`. 