### PR TITLE
Host reference genome

### DIFF
--- a/analyses/models.py
+++ b/analyses/models.py
@@ -159,6 +159,7 @@ class Run(
         LIBRARY_LAYOUT = "library_layout"
         LIBRARY_SOURCE = "library_source"
         SCIENTIFIC_NAME = "scientific_name"
+        HOST_TAX_ID = "host_tax_id"
 
     instrument_platform = models.CharField(
         db_column="instrument_platform", max_length=100, blank=True, null=True

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -152,6 +152,7 @@ class Run(
     TimeStampedModel, ENADerivedModel, MGnifyAutomatedModel, WithExperimentTypeModel
 ):
     class CommonMetadataKeys:
+        # TODO replace this with ENA result type pydantic model once available
         INSTRUMENT_PLATFORM = "instrument_platform"
         INSTRUMENT_MODEL = "instrument_model"
         FASTQ_FTPS = "fastq_ftps"
@@ -160,6 +161,7 @@ class Run(
         LIBRARY_SOURCE = "library_source"
         SCIENTIFIC_NAME = "scientific_name"
         HOST_TAX_ID = "host_tax_id"
+        HOST_SCIENTIFIC_NAME = "host_scientific_name"
 
     instrument_platform = models.CharField(
         db_column="instrument_platform", max_length=100, blank=True, null=True

--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -107,6 +107,7 @@ class ENAConfig(BaseModel):
         "library_source",
         "scientific_name",
         "host_tax_id",
+        "host_scientific_name",
     ]
 
     ftp_prefix: str = "ftp.sra.ebi.ac.uk/vol1/"

--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -106,6 +106,7 @@ class ENAConfig(BaseModel):
         "library_strategy",
         "library_source",
         "scientific_name",
+        "host_tax_id",
     ]
 
     ftp_prefix: str = "ftp.sra.ebi.ac.uk/vol1/"

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -526,6 +526,9 @@ def get_study_readruns_from_ena(
                     analyses.models.Run.CommonMetadataKeys.HOST_TAX_ID: read_run[
                         analyses.models.Run.CommonMetadataKeys.HOST_TAX_ID
                     ],
+                    analyses.models.Run.CommonMetadataKeys.HOST_SCIENTIFIC_NAME: read_run[
+                        analyses.models.Run.CommonMetadataKeys.HOST_SCIENTIFIC_NAME
+                    ],
                 }
             },
         )

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -523,6 +523,9 @@ def get_study_readruns_from_ena(
                         analyses.models.Run.CommonMetadataKeys.SCIENTIFIC_NAME
                     ],
                     analyses.models.Run.CommonMetadataKeys.FASTQ_FTPS: fastq_ftp_reads,
+                    analyses.models.Run.CommonMetadataKeys.HOST_TAX_ID: read_run[
+                        analyses.models.Run.CommonMetadataKeys.HOST_TAX_ID
+                    ],
                 }
             },
         )

--- a/workflows/tests/test_analysis_amplicon_study_flow.py
+++ b/workflows/tests/test_analysis_amplicon_study_flow.py
@@ -384,6 +384,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "sample_accession": "SAMN08514018",
@@ -397,6 +398,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "sample_accession": "SAMN08514019",
@@ -410,6 +412,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "sample_accession": "SAMN08514020",
@@ -423,6 +426,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "sample_accession": "SAMN08514021",
@@ -436,6 +440,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
         ],
     )

--- a/workflows/tests/test_analysis_amplicon_study_flow.py
+++ b/workflows/tests/test_analysis_amplicon_study_flow.py
@@ -383,6 +383,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
             {
                 "sample_accession": "SAMN08514018",
@@ -395,6 +396,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
             {
                 "sample_accession": "SAMN08514019",
@@ -407,6 +409,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
             {
                 "sample_accession": "SAMN08514020",
@@ -419,6 +422,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
             {
                 "sample_accession": "SAMN08514021",
@@ -431,6 +435,7 @@ async def test_prefect_analyse_amplicon_flow(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
         ],
     )

--- a/workflows/tests/test_assemble_study_flow.py
+++ b/workflows/tests/test_assemble_study_flow.py
@@ -15,6 +15,7 @@ import analyses.models
 import ena.models
 from workflows.flows.assemble_study import AssemblerChoices, assemble_study
 from workflows.flows.assemble_study_tasks.assemble_samplesheets import (
+    get_reference_genome,
     update_assemblies_assemblers_from_samplesheet,
 )
 from workflows.flows.assemble_study_tasks.make_samplesheets import (
@@ -79,6 +80,7 @@ async def test_prefect_assemble_study_flow(
                 "library_strategy": "WGS",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
             {
                 "sample_accession": "SAMN02",
@@ -91,6 +93,7 @@ async def test_prefect_assemble_study_flow(
                 "library_strategy": "WGS",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
         ],
     )
@@ -273,3 +276,28 @@ def test_assembler_changed_in_samplesheet(
         ).count()
         > 1
     )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_reference_genome_selection(prefect_harness, mgnify_assemblies, caplog):
+    study = analyses.models.Study.objects.first()
+
+    ref = get_reference_genome(study)
+    assert ref is None
+    assert f"Found no run in {study} with a host tax id" in caplog.text
+    caplog.clear()
+
+    run = study.runs.first()
+    run.metadata[analyses.models.Run.CommonMetadataKeys.HOST_TAX_ID] = (
+        999  # not a support tax id
+    )
+    run.save()
+    ref = get_reference_genome(study)
+    assert ref is None
+    assert f"Using run {run} for determining host" in caplog.text
+    caplog.clear()
+
+    run.metadata[analyses.models.Run.CommonMetadataKeys.HOST_TAX_ID] = 7460  # honeybee
+    run.save()
+    ref = get_reference_genome(study)
+    assert ref == "honeybee.fna"

--- a/workflows/tests/test_assemble_study_flow.py
+++ b/workflows/tests/test_assemble_study_flow.py
@@ -81,6 +81,7 @@ async def test_prefect_assemble_study_flow(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "sample_accession": "SAMN02",
@@ -94,6 +95,7 @@ async def test_prefect_assemble_study_flow(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
         ],
     )
@@ -284,7 +286,7 @@ def test_reference_genome_selection(prefect_harness, mgnify_assemblies, caplog):
 
     ref = get_reference_genome(study)
     assert ref is None
-    assert f"Found no run in {study} with a host tax id" in caplog.text
+    assert f"Found no run in {study} with host taxon info" in caplog.text
     caplog.clear()
 
     run = study.runs.first()
@@ -301,3 +303,11 @@ def test_reference_genome_selection(prefect_harness, mgnify_assemblies, caplog):
     run.save()
     ref = get_reference_genome(study)
     assert ref == "honeybee.fna"
+
+    run.metadata[analyses.models.Run.CommonMetadataKeys.HOST_TAX_ID] = None
+    run.metadata[analyses.models.Run.CommonMetadataKeys.HOST_SCIENTIFIC_NAME] = (
+        "Gallus gallus"  # chicken
+    )
+    run.save()
+    ref = get_reference_genome(study)
+    assert ref == "chicken.fna"

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -156,6 +156,7 @@ def test_get_study_readruns_from_ena(
                 "library_source": "GENOMIC",
                 "scientific_name": "genome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "run_accession": "RUN2",
@@ -169,6 +170,7 @@ def test_get_study_readruns_from_ena(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "run_accession": "RUN3",
@@ -182,6 +184,7 @@ def test_get_study_readruns_from_ena(
                 "library_source": "METAGENOME",
                 "scientific_name": "uncultured bacteria",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "run_accession": "RUN4",
@@ -195,6 +198,7 @@ def test_get_study_readruns_from_ena(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "run_accession": "RUN5",
@@ -208,6 +212,7 @@ def test_get_study_readruns_from_ena(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
             {
                 "run_accession": "RUN6",
@@ -221,6 +226,7 @@ def test_get_study_readruns_from_ena(
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
                 "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
             },
         ],
     )

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -155,6 +155,7 @@ def test_get_study_readruns_from_ena(
                 "library_strategy": "AMPLICON",
                 "library_source": "GENOMIC",
                 "scientific_name": "genome",
+                "host_tax_id": "7460",
             },
             {
                 "run_accession": "RUN2",
@@ -167,6 +168,7 @@ def test_get_study_readruns_from_ena(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
             {
                 "run_accession": "RUN3",
@@ -179,6 +181,7 @@ def test_get_study_readruns_from_ena(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOME",
                 "scientific_name": "uncultured bacteria",
+                "host_tax_id": "7460",
             },
             {
                 "run_accession": "RUN4",
@@ -191,6 +194,7 @@ def test_get_study_readruns_from_ena(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
             {
                 "run_accession": "RUN5",
@@ -203,6 +207,7 @@ def test_get_study_readruns_from_ena(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
             {
                 "run_accession": "RUN6",
@@ -215,6 +220,7 @@ def test_get_study_readruns_from_ena(
                 "library_strategy": "AMPLICON",
                 "library_source": "METAGENOMIC",
                 "scientific_name": "metagenome",
+                "host_tax_id": "7460",
             },
         ],
     )
@@ -256,6 +262,7 @@ def test_get_study_readruns_from_ena(
             and "_1" in run.metadata["fastq_ftps"][0]
             and "_2" in run.metadata["fastq_ftps"][1]
         )
+        assert run.metadata["host_tax_id"] == "7460"
 
 
 def test_ena_api_query_maker(httpx_mock):


### PR DESCRIPTION
This PR:
- fetches host taxonomy ID for runs when pulling them from ENA
- adds a lookup of host-tax-id to known reference genomes, based on currently available options in miassembler
- adds the `--reference_genome` flag to miassembler calls, if one can be determined

The reference genome selection is based on an exact match of the NCBI tax ID, between the reference genomes we currently support and the ENA metadata on any run in a study. This isn't perfect, because host tax IDs might be missing in metadata or be specific at some higher rank. But it is a start. I considered adding a flow-suspend if the assemblies about to be launched were from a host-associated biome but a tax ID couldn't be found... but I think this is too common. A better bet would probably be a way to bulk update the runs of a study, in the DB, e.g. to assert a host TAX ID onto them.

Also I decided to keep the lookup of tax-id > reference genome as in-code, instead of in-db, since these are also an in-code Enum in miassembler so a code change seemed appropriate to add new ones.