### PR TITLE
Submit assembly coverage-depth to ENA

### DIFF
--- a/workflows/flows/upload_assembly.py
+++ b/workflows/flows/upload_assembly.py
@@ -248,7 +248,7 @@ def generate_assembly_csv(
         line = ",".join(
             [
                 assembly.run.first_accession,
-                str(assembly.metadata.get(assembly.CommonMetadataKeys.COVERAGE)),
+                str(assembly.metadata.get(assembly.CommonMetadataKeys.COVERAGE_DEPTH)),
                 assembly.assembler.name,
                 str(assembly.assembler.version),
                 os.path.abspath(assembly_path),


### PR DESCRIPTION
Coverage-depth (not coverage) is the correct value to submit as assembly metadata, according to ENA docs.