### PR TITLE
Added spades for ion_torrent sequencing platform

### DIFF
--- a/analyses/models.py
+++ b/analyses/models.py
@@ -177,6 +177,7 @@ class Run(
         ILLUMINA = "ILLUMINA"
         OXFORD_NANOPORE = "OXFORD_NANOPORE"
         PACBIO_SMRT = "PACBIO_SMRT"
+        ION_TORRENT = "ION_TORRENT"
 
     objects = models.Manager()
     public_objects = PublicRunManager()


### PR DESCRIPTION
Spades supports SE for iontorrent
```
SPAdes is a versatile toolkit designed for assembly and analysis of sequencing data. SPAdes is primarily developed for Illumina sequencing data, but can be used for IonTorrent as well. Most of SPAdes pipelines support hybrid mode, i.e. allow using long reads (PacBio and Oxford Nanopore) as a supplementary data.

bin/spades.py --iontorrent -s it_reads.fastq -o output_folder
```