### PR TITLE
switch to per-run cache for tasks with side effects

### DIFF
--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -7,6 +7,7 @@ import httpx
 from django.conf import settings
 from httpx import Auth
 from prefect import flow, get_run_logger, task
+from prefect.tasks import task_input_hash
 from pydantic import BaseModel, Field, computed_field, field_serializer, model_validator
 from typing_extensions import Self
 
@@ -14,7 +15,6 @@ import analyses.models
 import ena.models
 from emgapiv2.enum_utils import FutureStrEnum
 from workflows.ena_utils.ena_auth import dcc_auth
-from workflows.prefect_utils.cache_control import context_agnostic_task_input_hash
 
 ALLOWED_LIBRARY_SOURCE: list = ["METAGENOMIC", "METATRANSCRIPTOMIC"]
 SINGLE_END_LIBRARY_LAYOUT: str = "SINGLE"
@@ -324,7 +324,7 @@ class ENAAvailabilityException(Exception): ...
 @task(
     retries=RETRIES,
     retry_delay_seconds=RETRY_DELAY,
-    cache_key_fn=context_agnostic_task_input_hash,
+    cache_key_fn=task_input_hash,
     task_run_name="Get study from ENA: {accession}",
 )
 def get_study_from_ena(accession: str, limit: int = 10) -> ena.models.Study:
@@ -441,7 +441,7 @@ def check_reads_fastq(fastq: list, run_accession: str, library_layout: str):
 @task(
     retries=RETRIES,
     retry_delay_seconds=RETRY_DELAY,
-    cache_key_fn=context_agnostic_task_input_hash,
+    cache_key_fn=task_input_hash,
     task_run_name="Get study readruns from ENA: {accession}",
 )
 def get_study_readruns_from_ena(

--- a/workflows/flows/analyse_study_tasks/sanity_check_amplicon_results.py
+++ b/workflows/flows/analyse_study_tasks/sanity_check_amplicon_results.py
@@ -2,17 +2,17 @@ import re
 from pathlib import Path
 
 from prefect import task, get_run_logger
+from prefect.tasks import task_input_hash
 
 from activate_django_first import EMG_CONFIG
 
 import analyses.models
 from workflows.flows.analyse_study_tasks.analysis_states import AnalysisStates
 from workflows.prefect_utils.analyses_models_helpers import task_mark_analysis_status
-from workflows.prefect_utils.cache_control import context_agnostic_task_input_hash
 
 
 @task(
-    cache_key_fn=context_agnostic_task_input_hash,
+    cache_key_fn=task_input_hash,
 )
 def sanity_check_amplicon_results(
     amplicon_current_outdir: Path, analysis: analyses.models.Analysis

--- a/workflows/flows/analyse_study_tasks/set_post_analysies_states.py
+++ b/workflows/flows/analyse_study_tasks/set_post_analysies_states.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List
 
 from prefect import task
+from prefect.tasks import task_input_hash
 
 from activate_django_first import EMG_CONFIG
 from workflows.flows.analyse_study_tasks.analysis_states import AnalysisStates
@@ -11,11 +12,10 @@ from workflows.flows.analyse_study_tasks.sanity_check_amplicon_results import (
     sanity_check_amplicon_results,
 )
 from workflows.prefect_utils.analyses_models_helpers import task_mark_analysis_status
-from workflows.prefect_utils.cache_control import context_agnostic_task_input_hash
 
 
 @task(
-    cache_key_fn=context_agnostic_task_input_hash,
+    cache_key_fn=task_input_hash,
 )
 def set_post_analysis_states(amplicon_current_outdir: Path, amplicon_analyses: List):
     # The pipeline produces top level end of execution reports, which contain

--- a/workflows/flows/upload_assembly.py
+++ b/workflows/flows/upload_assembly.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from assembly_uploader import assembly_manifest, study_xmls, submit_study
 from Bio import SeqIO
+from prefect.tasks import task_input_hash
 
 from activate_django_first import EMG_CONFIG
 
@@ -19,7 +20,6 @@ from prefect import flow, get_run_logger, task
 import analyses.models
 import ena.models
 from workflows.prefect_utils.analyses_models_helpers import task_mark_assembly_status
-from workflows.prefect_utils.cache_control import context_agnostic_task_input_hash
 from workflows.prefect_utils.slurm_flow import (
     ClusterJobFailedException,
     run_cluster_job,
@@ -153,7 +153,7 @@ def submit_study_xml(
 
 @task(
     retries=2,
-    cache_key_fn=context_agnostic_task_input_hash,
+    cache_key_fn=task_input_hash,
     task_run_name="Check study registration, create study XML and submit to ENA",
 )
 def handle_tpa_study(
@@ -333,7 +333,7 @@ def add_erz_accession(assembly: analyses.models.Assembly, erz_accession):
 
 @task(
     retries=2,
-    cache_key_fn=context_agnostic_task_input_hash,
+    cache_key_fn=task_input_hash,
     task_run_name="Run Webin-cli to upload {mgnify_assembly}",
 )
 def submit_assembly_slurm(


### PR DESCRIPTION
When a task has a side effect (like writing something to the DB, or uploading something to ENA) it is actually preferable to NOT cache this across flow runs ("context agnostic" in our speak). This is because one may want to retry that task, in a new flow, having taken out-of-band action on the side effect – i.e., deleted something from database or suppressed something in ENA. In this case, the task's cached/persisted result is of no use, as it does not mean that the side effect is currently in the desired state. TODO: consider how to convey this in our development documentation, it is a tricky concept.