### PR TITLE
Improves tolerance to prefect worker/server disconnects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN pip install https://github.com/PySlurm/pyslurm/archive/refs/tags/v21.8.1.tar
 ENV TZ="Etc/UTC"
 
 COPY . .
+RUN pip install -r requirements-dev.txt
 RUN pip install -r requirements-tools.txt
 
 ENTRYPOINT ["/usr/local/bin/submitter-entrypoint.sh", "python3", "manage.py"]

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -90,3 +90,51 @@ tasks:
       - mkdir -p slurm-dev-environment/fs/nfs/ftp/public/databases/metagenomics/mgnify_results/PRJNA398/PRJNA398089/SRR1111/SRR1111111/V6/
       - cp -r slurm-dev-environment/fs/nfs/public/tests/amplicon_v6_output/SRR1111111 slurm-dev-environment/fs/nfs/ftp/public/databases/metagenomics/mgnify_results/PRJNA398/PRJNA398089/SRR1111/SRR1111111/V6/amplicon
       - docker compose run app shell -c "from analyses.models import Analysis; a=Analysis.objects.get(accession='MGYA00000004'); a.results_dir='PRJNA398/PRJNA398089/SRR1111/SRR1111111/V6/amplicon'; a.save()"
+
+  debug-break-prefect-connection:
+    desc: "Temporarily return 404s from the prefect server, when prefect worker tries to access it"
+    vars:
+      DURATION: 60
+    cmds:
+      - docker exec -d prefect-agent touch /tmp/prefect_is_404
+      - echo "Interceptor active! Prefect API calls will now return 404."
+      - sleep {{.DURATION}}
+      - docker exec prefect-agent rm /tmp/prefect_is_404
+    silent: false
+    summary: |
+      To test connection interruption, e.g.:
+      $  FLOW=slow_cluster_job_example task deploy-flow
+      $  task prefect -- deployment run  'Slow running cluster job example/slow_cluster_job_example_deployment' -p run_for_seconds=120
+      ... wait for that flow to start its cluster job in prefect UI ...
+      $ task debug-break-prefect-connection
+      ... you will see that the worker stops reporting logs for a while, but should not crash thanks to retries ...
+
+  debug-make-prefect-flow-with-zombie-job:
+    desc: "Make a prefect flow in which there is a zombie cluster job (one where prefect worker died whilst running slurm job)"
+    cmds:
+      - task: prefect
+        vars:
+          {CLI_ARGS: "deployment run 'Slow running cluster job example/slow_cluster_job_example_deployment' -p run_for_seconds=60 -p slurm_resubmit_policy_minutes_ago=5"}
+      - sleep 30
+      - docker compose kill prefect-agent
+      - sleep 60
+      - docker compose start prefect-agent
+    summary: |
+      To make jobs in zombie state, for developing cleanup tools and investigating state management etc.
+      You need to have deployed the `slow_cluster_job_example` flow to use this one, e.g.
+      $ FLOW=slow_cluster_job_example task deploy-flow
+      The task sets off a flow, that runs a 60second cluster job.
+      ~Half way through that job, the prefect worker is killed for 60 seconds,
+      so the cluster job should have finished whilst the worker was offline.
+      This results in a zombie state flow and subflow, because the prefect server assumes the worker will
+      somehow pick up where it left off.
+
+      Can then use e.g.
+      $ task manage -- reconnect_zombie_jobs -t 30
+      to try and cleanup/retry the zombie flow.
+
+      Since slurm_resubmit_policy_minutes_ago=5,
+      if you run the reconnect_zombie_jobs shortly after the zombie job is made,
+      you can verify that the slurm job actually continued to run or completed in the background and is
+      "reconnected" to by the restarted flow.
+      This is desired behaviour.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,6 +82,10 @@ services:
       - PREFECT_API_URL=http://prefect-server:4200/api
       - PREFECT_LOCAL_STORAGE_PATH=/root/.prefect/storage
       - DATABASE_URL=postgres://postgres:postgres@app-database:5432/emg
+      - HTTP_PROXY=http://localhost:8080
+      - HTTPS_PROXY=https://localhost:8080
+      - http_proxy=http://localhost:8080
+      - https_proxy=https://localhost:8080
     profiles: ["prefect", "all"]
     env_file:
       - path: ./secrets-local.env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,15 @@ exclude = ["emgapiv2/settings_test.py"]
 [tool.setuptools]
 python_requires = ">=3.10"
 
+[tool.prefect]
+logging.level = "DEBUG"
+# debug_mode = true
+# allow for 1 hour of prefect-server downtime
+client.max_retries = 60 # 1 hour elapsed from first to last try, since delay increases by 2*try-count seconds.
+client.retry_extra_codes = [404]  # for times when some traffic management between worker and prefect server breaks
+api.request_timeout = 120 # 2 mins
+server.api.keepalive_timeout = 60 # seconds
+
 #TODO, when ruff supports custom section-ordering
 #[tool.ruff.isort]
 #section-order = ["future", "standard-library", "third-party", "activate_django_first", "first-party", "local-folder"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ pytest-asyncio
 pytest-env
 pytest-sugar
 pytest-responses
+mitmproxy

--- a/slurm-dev-environment/debug_tools/prefect_agent_mitm.py
+++ b/slurm-dev-environment/debug_tools/prefect_agent_mitm.py
@@ -1,0 +1,27 @@
+import os
+from mitmproxy import http
+
+"""
+This file configures the MITM rules present in the dev prefect-agent.
+It can therefore be used to simulate network interruptions.
+It uses flag files for conditional routing, so that e.g.
+a Taskfile task can touch a file in the container to temporarily
+alter the routing rules.
+"""
+
+INTERCEPT_404_PATH = "/tmp/prefect_is_404"
+
+
+def request(flow: http.HTTPFlow):
+    api = os.getenv("PREFECT_API_URL")
+    if not api:
+        raise UserWarning("PREFECT_API_URL env var not set")
+
+    # If the flag file exists, return 404 for API requests
+    if os.path.exists(INTERCEPT_404_PATH) and flow.request.pretty_url.startswith(api):
+        flow.response = http.Response.make(
+            404,  # HTTP status code
+            b"Not Found",  # Response body
+            {"Content-Type": "text/plain"},  # Headers
+        )
+        return

--- a/slurm-dev-environment/entrypoints/submitter-entrypoint.sh
+++ b/slurm-dev-environment/entrypoints/submitter-entrypoint.sh
@@ -7,4 +7,8 @@ chown -R munge:munge /etc/munge
 echo "ℹ️ Start munged for auth"
 gosu munge /usr/sbin/munged
 
+echo "ℹ️ Start mitmdump for intercepting"
+mitmdump --mode regular -s /app/slurm-dev-environment/debug_tools/prefect_agent_mitm.py &
+
+echo "ℹ️ Helpers all started"
 exec "$@"

--- a/workflows/flows/slow_cluster_job_example.py
+++ b/workflows/flows/slow_cluster_job_example.py
@@ -1,0 +1,46 @@
+import shutil
+from datetime import timedelta
+from pathlib import Path
+
+from prefect import flow
+
+from activate_django_first import EMG_CONFIG
+
+from workflows.prefect_utils.slurm_flow import run_cluster_job
+from workflows.prefect_utils.slurm_policies import _SlurmResubmitPolicy, ANYTHING
+
+
+@flow(
+    name="Slow running cluster job example",
+    log_prints=True,
+)
+def slow_cluster_job_example(
+    run_for_seconds: int, slurm_resubmit_policy_minutes_ago: int = 60
+):
+    assert run_for_seconds > 10
+
+    ResubmitIfOlderThanXPolicy = _SlurmResubmitPolicy(
+        policy_name=f"Do not resubmit if identical job was submitted more recently than {slurm_resubmit_policy_minutes_ago} minutes ago",
+        given_previous_job_submitted_after=timedelta(
+            minutes=-slurm_resubmit_policy_minutes_ago
+        ),
+        if_status_matches=ANYTHING,
+        then_resubmit=False,
+    )
+
+    command = f"HOW_LONG={run_for_seconds}; for ((i=0; i<HOW_LONG; i+=5)); do date; sleep 5; done"
+
+    workdir = Path(EMG_CONFIG.slurm.default_workdir) / "slow-example"
+
+    shutil.rmtree(workdir, ignore_errors=True)
+    workdir.mkdir(exist_ok=True)
+
+    run_cluster_job(
+        name=f"Tell the time every 5 seconds for {run_for_seconds} seconds",
+        command=command,
+        expected_time=timedelta(seconds=run_for_seconds + 10),
+        memory="100M",
+        resubmit_policy=ResubmitIfOlderThanXPolicy,
+        working_dir=workdir,
+        environment={},
+    )

--- a/workflows/management/commands/force_flow_to_be_crashed.py
+++ b/workflows/management/commands/force_flow_to_be_crashed.py
@@ -1,0 +1,52 @@
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from prefect import get_client, State
+from prefect.exceptions import ObjectNotFound
+from prefect.server.schemas.states import StateType
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = (
+        "Force mark a prefect flow as crashed. Does not impact any parent or subflows."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-f",
+            "--flow_run_id",
+            type=str,
+            help="The UUID of the flow run to be forcibly transitioned to Crashed state",
+            required=True,
+        )
+        parser.add_argument(
+            "-m",
+            "--message",
+            type=str,
+            help="Optional detail message to attach to the Crashed state, e.g. explaining why.",
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        with get_client(sync_client=True) as client:
+            try:
+                flow_run = client.read_flow_run(options["flow_run_id"])
+            except ObjectNotFound:
+                raise CommandError(f"No flow run found for {options['flow_run_id']}")
+
+            crashed_state = State(
+                type=StateType.CRASHED,
+                name="Crashed (Manually)",
+                message=options["message"] or None,
+            )
+
+            logger.info(f"Run is {flow_run}")
+
+            client.set_flow_run_state(flow_run.id, crashed_state, force=True)
+
+            flow_run_now = client.read_flow_run(flow_run.id)
+            logger.info(f"Run is now {flow_run_now}")

--- a/workflows/management/commands/reconnect_zombie_jobs.py
+++ b/workflows/management/commands/reconnect_zombie_jobs.py
@@ -1,0 +1,125 @@
+import logging
+from datetime import timedelta
+from uuid import UUID
+
+from django.core.management.base import BaseCommand
+from django.utils.timezone import now
+from pendulum import DateTime
+from prefect import get_client, State
+from prefect.client.orchestration import SyncPrefectClient
+from prefect.server.schemas.states import StateType
+
+from workflows.models import OrchestratedClusterJob
+from workflows.prefect_utils.find_parent_flow_run import (
+    find_parent_flow_runs_recursively,
+)
+from workflows.prefect_utils.slurm_status import SlurmStatus
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = "Finds zombie jobs – cluster jobs whose prefect orchestrating flows seems to have died – and restarts their flows."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-t",
+            "--tolerance_seconds",
+            type=int,
+            help="How many seconds may have elapsed since a cluster job was last updated, to be not considered zombie.",
+            required=True,
+        )
+
+    @staticmethod
+    def crash_flow(
+        client: SyncPrefectClient,
+        flow_run_id: UUID,
+        state_name: str,
+        state_message: str | None,
+    ) -> State:
+        crashed_state = State(
+            type=StateType.CRASHED, name=state_name, message=state_message
+        )
+        client.set_flow_run_state(flow_run_id, crashed_state, force=True)
+
+    def handle_zombie_orchestrated_cluster_job(
+        self, orchestrated_cluster_job: OrchestratedClusterJob, tolerance: DateTime
+    ):
+        with get_client(sync_client=True) as client:
+            logger.info(f"Handling {orchestrated_cluster_job}")
+            flow_run_id = orchestrated_cluster_job.flow_run_id
+            logger.info(f"Flow run ID {orchestrated_cluster_job.flow_run_id}")
+
+            flow_run = client.read_flow_run(flow_run_id)
+            logger.info(f"Flow run is {flow_run.id}")
+            logger.debug(f"Flow run detail {flow_run}")
+            if not flow_run.state.is_running():
+                logger.info(f"But flow run is {flow_run.state}")
+                return
+
+            logger.info("Flow is supposedly running")
+
+            if flow_run.updated > tolerance:
+                logger.info(f"But flow run was updated recently at {flow_run.updated}")
+                return
+
+            logger.info(
+                "Flow run was also updated longer ago than zombie-tolerance time"
+            )
+
+            logger.warning("Crashing flow")
+
+            self.crash_flow(
+                client=client,
+                flow_run_id=flow_run_id,
+                state_name="Crashed (Zombie)",
+                state_message="Crashed by reconnect_zombie_job",
+            )
+
+            flow_run_post = client.read_flow_run(flow_run_id)
+            logger.info(f"Flow run now is {flow_run_post.state}")
+
+            parent_flow_runs = find_parent_flow_runs_recursively(flow_run_post)
+
+            for parent_flow_run in parent_flow_runs:
+                logger.info(
+                    f"Parent flow run {parent_flow_run.id} will also be crashed"
+                )
+                self.crash_flow(
+                    client=client,
+                    flow_run_id=parent_flow_run.id,
+                    state_name="Crashed (Zombie)",
+                    state_message="Crashed by reconnect_zombie_job, as parent of a zombie flow",
+                )
+
+            head_flow_run = parent_flow_runs[0] if parent_flow_runs else flow_run_post
+            # the one to restart
+            restart_state = State(
+                type=StateType.SCHEDULED,
+                name="Awaiting restart",
+                message="Restarted by reconnect_zombie_job, since this or a subflow was in a zombie state",
+            )
+            client.set_flow_run_state(flow_run_id=head_flow_run.id, state=restart_state)
+
+            head_flow_run_post = client.read_flow_run(head_flow_run.id)
+            logger.info(
+                f"Restarted head flow run {head_flow_run.id} / {head_flow_run.name}: state is now {head_flow_run_post.state}"
+            )
+
+    def handle(self, *args, **options):
+        zombies_if_before = now() - timedelta(seconds=options["tolerance_seconds"])
+        logger.info(
+            f"Looking for RUNNING cluster jobs last updated before {zombies_if_before.isoformat()}"
+        )
+
+        probable_zombie_jobs = OrchestratedClusterJob.objects.filter(
+            last_known_state=SlurmStatus.running, state_checked_at__lt=zombies_if_before
+        )
+        logger.info(f"Found {probable_zombie_jobs.count()} such jobs")
+
+        for ocj in probable_zombie_jobs:
+            self.handle_zombie_orchestrated_cluster_job(
+                ocj, tolerance=zombies_if_before
+            )

--- a/workflows/prefect_utils/find_parent_flow_run.py
+++ b/workflows/prefect_utils/find_parent_flow_run.py
@@ -1,0 +1,42 @@
+import logging
+
+from prefect import get_client
+from prefect.client.schemas import FlowRun
+from prefect.client.schemas.filters import TaskRunFilter, TaskRunFilterId
+
+from analyses.management.commands.import_v5_analysis import logger
+
+
+def find_parent_flow_run(subflow_run: FlowRun) -> FlowRun | None:
+    if not subflow_run.parent_task_run_id:
+        logger.warning(f"Subflow {subflow_run.id} has no dummy parent task run")
+        return None
+    with get_client(sync_client=True) as client:
+        flow_runs_with_parent_task = client.read_flow_runs(
+            task_run_filter=TaskRunFilter(
+                id=TaskRunFilterId(any_=[subflow_run.parent_task_run_id])
+            )
+        )
+    try:
+        return flow_runs_with_parent_task[0]
+    except IndexError:
+        logging.warning(
+            f"No flow run found with dummy parent task id {subflow_run.parent_task_run_id}"
+        )
+        return None
+
+
+def find_parent_flow_runs_recursively(subflow_run: FlowRun) -> list[FlowRun]:
+    top_most_flow_run_known = subflow_run
+    parent_flow_runs = []
+
+    with get_client(sync_client=True) as client:
+        while True:
+            flow_run = client.read_flow_run(top_most_flow_run_known.id)
+            parent_flow_run = find_parent_flow_run(flow_run)
+            if not parent_flow_run:
+                break
+            top_most_flow_run_known = parent_flow_run
+            parent_flow_runs.append(parent_flow_run)
+
+    return parent_flow_runs


### PR DESCRIPTION
This PR:
- increments (wildly) some timeouts associated with prefect worker/server network disconnects, so that prefect server will not die so quickly if connection is lost
- adds 404 error code to list of codes that prefect worker will acceptably retry – this is because, in production, something in the network stack temporarily returns 404s (e.g. a load balancer, or http proxy).
Together, these means that prefect worker will tolerate about an hour of getting 404s from the API before dying.

- adds debug helpers to dev env for reproducing network failures between prefect worker and server
  - there is now a `mitmproxy` running in the prefect worker (aka agent) container, so that network traffic can be Man-In-The-Middled. E.g. we can add a flag file into running worker container, and then the `mitmproxy` will start giving 404s.
  - added some Taskfile tasks for reproducing network problems and making zombie jobs for debugging.
    - these aren't well suited to being pytest tests really... so are sort of manual integration tests. Maybe one day we can think of a better way to turn these into an actual assertive test suite
- adds cleanup tools (django management commands) for finding, manually marking-as-crashed, and restarting zombie jobs/flows
- removes the hook that was meant to cancel a slurm job if its orchestrating prefect flow was cancelled. This is because this seemed to cause problems where flows could not be cancelled if their worker had died, since the flow cancellation hook was expected to run in the flow's existing process context