### PR TITLE
Clean workdirs

### DIFF
--- a/workflows/flows/assemble_study_tasks/archive_assembly_dirs.py
+++ b/workflows/flows/assemble_study_tasks/archive_assembly_dirs.py
@@ -1,0 +1,92 @@
+import operator
+from functools import reduce
+from pathlib import Path
+
+from prefect import flow, get_run_logger
+
+from activate_django_first import EMG_CONFIG
+from analyses.models import Study, Assembly
+
+
+@flow(
+    name="Archive assembly directories",
+    flow_run_name="Archive assembly directories of {reads_study_mgys}",
+)
+def archive_assembly_dirs(reads_study_mgys: str, dry_run: bool = True):
+    """
+    Currently this deletes miassembler workdirs provided the study is in a suitable state of uploaded/inactive assemblies.
+    In future, it might move assembly dirs to LTS or a results archive if needed.
+    """
+    logger = get_run_logger()
+
+    study = Study.objects.get(accession=reads_study_mgys)
+    logger.info(f"Study is {study}")
+
+    assemblies_started = study.assemblies_reads.filter_by_statuses(
+        [Assembly.AssemblyStates.ASSEMBLY_STARTED]
+    )
+    logger.info(
+        f"Study has {assemblies_started.count()} reads-assemblies in STARTED state"
+    )
+
+    is_terminal_filters = study.assemblies_reads.get_queryset()._build_q_objects(
+        keys=[
+            Assembly.AssemblyStates.ASSEMBLY_UPLOADED,
+            Assembly.AssemblyStates.ASSEMBLY_BLOCKED,
+            Assembly.AssemblyStates.ASSEMBLY_FAILED,
+            Assembly.AssemblyStates.PRE_ASSEMBLY_QC_FAILED,
+            Assembly.AssemblyStates.POST_ASSEMBLY_QC_FAILED,
+        ],
+        allow_null=True,
+        truthy_target=True,
+    )
+
+    is_terminal = reduce(operator.or_, is_terminal_filters)
+
+    if (started_not_finished := assemblies_started.exclude(is_terminal)).exists():
+        logger.warning(
+            f"{started_not_finished.count()} of the assemblies are not in any terminal state."
+        )
+        logger.warning(f"**Not** cleaning {study}")
+        return
+
+    # Assembly workdir roots could be in any ena-accession prefixed dir, with or without samplesheet hash
+    # e.g. one of
+    # /nfs/.../slurm_workdir/ERP123_miassembler/
+    # /nfs/.../slurm_workdir/PRJ123_miassembler/
+    # /nfs/.../slurm_workdir/ERP123_miassembler/abcdef123456
+    # /nfs/.../slurm_workdir/PRJ123_miassembler/abcdef123456
+    # Look directly, since we may be cleaning folders that have not appeared in an assembly .dir field (if all FAILED)
+
+    potential_workdirs_roots = {
+        Path(EMG_CONFIG.slurm.default_workdir)
+        / f"{study.ena_study.accession}_miassembler",
+    }.union(
+        {
+            Path(EMG_CONFIG.slurm.default_workdir) / f"{acc}_miassembler"
+            for acc in study.ena_accessions
+        }
+    )
+
+    for potential_workdirs_root in potential_workdirs_roots:
+        if not potential_workdirs_root.is_dir():
+            logger.info(
+                f"No directory found at {potential_workdirs_root}. Nothing to be done."
+            )
+        logger.info(f"Looking for workdirs under {potential_workdirs_root}")
+
+        if (workdir := potential_workdirs_root / "work").is_dir():
+            logger.warning(f"Found workdir {workdir}. Deleting it.")
+            if dry_run:
+                logger.info("No action since in dry_run mode.")
+            else:
+                workdir.rmdir()
+
+        samplesheet_workdirs = potential_workdirs_root.glob("**/work")
+        for workdir in samplesheet_workdirs:
+            if workdir.is_dir():
+                logger.warning(f"Found workdir {workdir}. Deleting it.")
+                if dry_run:
+                    logger.info("No action since in dry_run mode.")
+                else:
+                    workdir.rmdir()

--- a/workflows/management/commands/clear_workdirs.py
+++ b/workflows/management/commands/clear_workdirs.py
@@ -1,0 +1,52 @@
+import logging
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.db.models import Max
+from django.utils.timezone import now
+
+from analyses.models import Study
+from workflows.flows.assemble_study_tasks.archive_assembly_dirs import (
+    archive_assembly_dirs,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = "Clear some known work directories. Currently: miassembler only."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-t",
+            "--tolerance_days",
+            type=int,
+            help="How many days must have elapsed since a study or its assemblies were last updated, to consider it for cleaning.",
+            required=True,
+        )
+        parser.add_argument(
+            "-n",
+            "--dry_run",
+            help="If set, just print what would be done without deleting anything.",
+            action="store_true",
+        )
+
+    def handle(self, *args, **options):
+        self.before = now() - timedelta(days=options["tolerance_days"])
+        logger.info(f"Will clean workdirs for objects not updated since {self.before}")
+
+        self._clean_assemblies(*args, **options)
+
+    def _clean_assemblies(self, *args, **options):
+        cleanable_studies = Study.objects.annotate(
+            last_updated_assembly=Max("assemblies_reads__updated_at")
+        ).filter(
+            updated_at__lt=self.before,
+            last_updated_assembly__isnull=False,
+            last_updated_assembly__lt=self.before,
+        )
+
+        for study in cleanable_studies:
+            logger.info(f"Cleaning study {study}")
+            archive_assembly_dirs(study.accession, dry_run=options["dry_run"])

--- a/workflows/tests/test_workdir_cleaning.py
+++ b/workflows/tests/test_workdir_cleaning.py
@@ -1,0 +1,108 @@
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+from django.conf import settings
+from django.core.management import call_command
+from django.db.models import Max
+from django.utils.timezone import now
+
+from analyses.models import Study
+import ena.models as ena_models
+from workflows.flows.assemble_study_tasks.archive_assembly_dirs import (
+    archive_assembly_dirs,
+)
+
+EMG_CONFIG = settings.EMG_CONFIG
+
+
+@pytest.mark.django_db
+def test_clean_assembly_workdirs(prefect_harness, mgnify_assemblies_completed, caplog):
+    workdir_root = Path(EMG_CONFIG.slurm.default_workdir)
+
+    study: Study = mgnify_assemblies_completed.first().reads_study
+
+    unrelated_ena_study, _ = ena_models.Study.objects.get_or_create(
+        accession="PRJunrelated", title="An unrelated study"
+    )
+    unrelated_study, _ = Study.objects.get_or_create(
+        ena_study=unrelated_ena_study, title=unrelated_ena_study.title
+    )
+
+    top_level_workdir_for_study = (
+        workdir_root / f"{study.ena_study.accession}_miassembler" / "work"
+    )
+    samplesheet_workdir_for_study = (
+        workdir_root
+        / f"{study.ena_study.accession}_miassembler"
+        / "samplesheet"
+        / "work"
+    )
+
+    def setup_dirs():
+        # make some dummy workdirs
+        for assembly in mgnify_assemblies_completed:
+            top_level_workdir_for_study.mkdir(exist_ok=True, parents=True)
+            (
+                workdir_root
+                / f"{study.ena_study.accession}_miassembler"
+                / "samplesheet"
+                / f"{study.first_accession}"
+                / f"{assembly.run.first_accession}"
+            ).mkdir(exist_ok=True, parents=True)
+            samplesheet_workdir_for_study.mkdir(exist_ok=True, parents=True)
+            assembly.dir = str(
+                workdir_root
+                / f"{study.ena_study.accession}_miassembler"
+                / "samplesheet"
+                / f"{study.first_accession}"
+                / f"{assembly.run.first_accession}"
+            )
+            assembly.save()
+
+        (workdir_root / "work").mkdir(exist_ok=True, parents=True)
+
+        # make some workdirs that should not be touched
+        (workdir_root / "PRJunrelated" / "work").mkdir(exist_ok=True, parents=True)
+
+    # call prefect flow for the study to be cleaned
+    setup_dirs()
+    archive_assembly_dirs(study.accession, dry_run=False)
+    assert not top_level_workdir_for_study.exists()
+    assert not samplesheet_workdir_for_study.exists()
+
+    first_assembly = mgnify_assemblies_completed.first()
+    assert Path(first_assembly.dir).exists()
+
+    # call flow via management command for an e2e test
+    setup_dirs()
+    caplog.clear()
+    with caplog.at_level("INFO"):
+        call_command("clear_workdirs", tolerance_days=1)
+
+    ## should not have cleaned anything because a day has not passed
+    assert top_level_workdir_for_study.exists()
+    assert samplesheet_workdir_for_study.exists()
+
+    # make study + assemblies be updated in the past
+    study.updated_at = now() - timedelta(days=3)
+    Study.objects.bulk_update([study], ["updated_at"])
+
+    study.assemblies_reads.update(updated_at=now() - timedelta(days=3))
+
+    study.refresh_from_db()
+    print(f"study updated at {study.updated_at}")
+    print(study.assemblies_reads.aggregate(Max("updated_at")))
+
+    caplog.clear()
+    with caplog.at_level("INFO"):
+        call_command("clear_workdirs", tolerance_days=1)
+    print("--- THE LOG ---")
+    print(caplog.text)
+    print("--- ------- ---")
+
+    ## should now have cleaned only first study, since unrelated one was edited today
+    assert not top_level_workdir_for_study.exists()
+    assert not samplesheet_workdir_for_study.exists()
+
+    assert (workdir_root / "PRJunrelated" / "work").exists()


### PR DESCRIPTION
This PR:
- adds a flow `archive_assembly_dirs` which takes a study and will move/archive/clean its assembly dirs. Right now it just finds and delete nextflow `work` directories. In future, it may move the dirs to a backup location by adding a datamover subflow. It has some logic to not clean studies if there are unfinished assemblies.
- adds a management command to find studies suitable for cleaning. Right now that is reads studies with assemblies that haven't been updated for a while.

Future expansion:
- archiving of dirs
- use of `nextflow clean` to also clean up caches and logs if desired
- analysis studies if needed
- auto clean studies at the end of a reasonbly successful assembly flow