### PR TITLE
Fix credentials used for private assembly-uploader

### DIFF
--- a/workflows/flows/upload_assembly.py
+++ b/workflows/flows/upload_assembly.py
@@ -286,7 +286,7 @@ def prepare_assembly(
 
     with TemporaryEnv(
         ENA_WEBIN=(
-        f"{EMG_CONFIG.webin.broker_prefix}{mgnify_assembly.reads_study.webin_submitter}"
+            f"{EMG_CONFIG.webin.broker_prefix}{mgnify_assembly.reads_study.webin_submitter}"
             if mgnify_assembly.is_private
             else UNSET
         ),


### PR DESCRIPTION
Recent changes to assembly uploader (to make it usable by users without dcc credentials), mean that the wrong credentials are being passed to the assembly manifest generator. This means the run metadata cannot be fetched and assembly uploads are failing.
This PR switches from the dcc credentials (only usable by some) to broker credentials and for the Webin Reports API (which are interchangable with regular Webin credentials so work for all).