### PR TITLE
Private amplicon data analysis

### DIFF
--- a/.aiignore
+++ b/.aiignore
@@ -1,0 +1,14 @@
+# An .aiignore file follows the same syntax as a .gitignore file.
+# .gitignore documentation: https://git-scm.com/docs/gitignore
+# Junie will ask for explicit approval before view or edit the file or file within a directory listed in .aiignore.
+# Only files contents is protected, Junie is still allowed to view file names even if they are listed in .aiignore.
+# Be aware that the files you included in .aiignore can still be accessed by Junie in two cases:
+# - If Brave Mode is turned on.
+# - If a command has been added to the Allowlist — Junie will not ask for confirmation, even if it accesses - files and folders listed in .aiignore.
+secret*.yaml
+secret*.yml
+secret*.env
+secret*.htaccess
+deployment/**/auth
+*env/
+talisman_report/

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 from typing import ClassVar, Union
 
+from aenum import extend_enum
 from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import models
@@ -213,8 +214,11 @@ class PublicRunManager(PrivacyFilterManagerMixin, models.Manager): ...
 
 class Run(TimeStampedModel, ENADerivedModel, WithExperimentTypeModel):
     CommonMetadataKeys = ENAReadRunFields
-    CommonMetadataKeys.FASTQ_FTPS = (
-        "fastq_ftps"  # plural convention mismatch to ENA; TODO
+    extend_enum(
+        CommonMetadataKeys, "FASTQ_FTPS", "fastq_ftps"
+    ),  # plural convention mismatch to ENA; TODO
+    extend_enum(
+        CommonMetadataKeys, "INFERRED_LIBRARY_LAYOUT", "inferred_library_layout"
     )
 
     class InstrumentPlatformKeys:

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -84,9 +84,11 @@ class StudyManager(ENADerivedManager):
             ).first()
             logger.debug(f"Got {ena_study}")
         except (MultipleObjectsReturned, ObjectDoesNotExist):
-            logger.warning(
-                f"Problem getting ENA study {ena_study_accession} from ENA models DB"
+            logger.error(
+                f"Problem getting ENA study {ena_study_accession} from ENA models DB. "
+                f"The ENA Study needs to have been fetched from ENA APIs first."
             )
+            raise
         study, _ = Study.objects.get_or_create(
             ena_study=ena_study,
             title=ena_study.title,

--- a/conftest.py
+++ b/conftest.py
@@ -24,6 +24,7 @@ pytest_plugins = [
     "analyses.fixtures.study.conftest",
     "workflows.fixtures.legacy_emg_dbs.conftest",
     "workflows.fixtures.slurm.conftest",
+    "workflows.fixtures.flowrun_input.conftest",
     "workflows.nextflow_utils.fixtures.conftest",
 ]
 

--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -12,6 +12,7 @@ class SlurmConfig(BaseModel):
     default_workdir: str = "/nfs/production/dev-slurm-work-dir"
     pipelines_root_dir: str = "/app/workflows/pipelines"
     ftp_results_dir: str = "/nfs/ftp/public/databases/metagenomics/mgnify_results"
+    private_results_dir: str = "/nfs/public/services/private-data"
     user: str = "root"
 
     incomplete_job_limit: int = 100

--- a/emgapiv2/enum_utils.py
+++ b/emgapiv2/enum_utils.py
@@ -1,13 +1,13 @@
-import enum
+import aenum
 
 from django.utils.version import PY311
 
 # Define StrEnum for Python3.10, to work like 3.11+
 if PY311:  # or later
-    FutureStrEnum = enum.StrEnum
+    FutureStrEnum = aenum.StrEnum
 else:
 
-    class FutureStrEnum(str, enum.Enum):
+    class FutureStrEnum(str, aenum.Enum):
         def __str__(self):
             return str(self.value)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ httpx~=0.28.1
 typing_extensions~=4.13.2
 asgiref~=3.8.1
 case-converter~=1.2.0
+aenum~=3.1.16

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -1,7 +1,7 @@
 import operator
 from datetime import timedelta
 from functools import reduce
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Type, Union, Literal
 
 from django.conf import settings
 from httpx import Auth
@@ -130,45 +130,61 @@ def get_study_from_ena(accession: str, limit: int = 10) -> ena.models.Study:
 
 def check_reads_fastq(
     fastq: list[str], run_accession: str, library_layout: str
-) -> list[str] | None:
-    logger = get_run_logger()
+) -> tuple[List[str] | None, Literal["SINGLE", "PAIRED", None]]:
+    """
+    Analyses and validates a list of FASTQ files for a given run accession and
+    specified library layout. Ensures the FASTQ files align with the expected
+    library layout, such as single-end or paired-end sequencing data.
+
+    :param fastq: A list of FASTQ file paths associated with the sequencing run.
+    :param run_accession: The unique identifier for the sequencing run.
+    :param library_layout: The specified library layout for the data. This should
+        indicate whether the data is single-end ("SINGLE") or paired-end ("PAIRED").
+    :return: A tuple containing the sorted FASTQ file paths and the inferred library
+        layout as "SINGLE" or "PAIRED", or None if validation fails or no valid FASTQ
+        files are provided.
+    """
+    logger = get_run_logger()  # TODO: make this method okay to use outside of prefect
     sorted_fastq = sorted(fastq)  # to keep order [_1, _2, _3(?)]
-    if not len(sorted_fastq):
-        logger.warning(f"No fastq files for run {run_accession}")
-        return None
     # potential single end
-    elif len(sorted_fastq) == 1:
+    if len(sorted_fastq) == 1:
+        if not sorted_fastq[0]:
+            # if it's an empty string
+            logger.warning(f"No fastq files for run {run_accession}")
+            return None, None
+        if "_2.f" in sorted_fastq[0]:
+            # we accept _1 be in SE fastq path
+            logger.warning(f"Single fastq file contains _2 for run {run_accession}")
+            return None, None
         if library_layout == PAIRED_END_LIBRARY_LAYOUT:
             logger.warning(
                 f"Incorrect library_layout for {run_accession} having one fastq file"
             )
-            return None
-        if "_2.f" in sorted_fastq[0]:
-            # we accept _1 be in SE fastq path
-            logger.warning(f"Single fastq file contains _2 for run {run_accession}")
-            return None
+            return sorted_fastq, "SINGLE"
         else:
             logger.info(f"One fastq for {run_accession}: {sorted_fastq}")
-            return sorted_fastq
+            return sorted_fastq, "SINGLE"
     # potential paired end
-    elif len(sorted_fastq) == 2:
-        if library_layout == SINGLE_END_LIBRARY_LAYOUT:
-            logger.warning(
-                f"Incorrect library_layout for {run_accession} having two fastq files"
-            )
-            return None
-        if "_1.f" in sorted_fastq[0] and "_2.f" in sorted_fastq[1]:
+    elif len(sorted_fastq) >= 2:
+        match_1 = next((f for f in sorted_fastq if "_1" in f), None)
+        match_2 = next((f for f in sorted_fastq if "_2" in f), None)
+        if match_1 and match_2:
             logger.info(f"Two fastqs for {run_accession}: {sorted_fastq}")
-            return sorted_fastq
+            return [match_1, match_2], "PAIRED"
         else:
+            if len(sorted_fastq) > 2:
+                logger.warning(
+                    f"More than 2 fastq files provided for run {run_accession}"
+                )
+            else:
+                logger.warning(
+                    f"Incorrect library_layout for {run_accession} having two fastq files"
+                )
             logger.warning(
                 f"Incorrect names of fastq files for run {run_accession} (${sorted_fastq})"
             )
-            return None
-    elif len(fastq) > 2:
-        logger.info(f"More than 2 fastq files provided for run {run_accession}")
-        return sorted_fastq[:2]
-    return None
+            return None, None
+    return None, None
 
 
 def _make_samples_and_run(
@@ -327,7 +343,7 @@ def get_study_readruns_from_ena(
             continue
 
         # check fastq files order/presence
-        fastq_ftp_reads = check_reads_fastq(
+        fastq_ftp_reads, inferred_library_layout = check_reads_fastq(
             fastq=read_run[_.FASTQ_FTP].split(";"),
             run_accession=read_run[_.RUN_ACCESSION],
             library_layout=read_run[_.LIBRARY_LAYOUT],
@@ -344,6 +360,13 @@ def get_study_readruns_from_ena(
         run.metadata[analyses.models.Run.CommonMetadataKeys.FASTQ_FTPS] = (
             fastq_ftp_reads
         )
+        if not inferred_library_layout == read_run[_.LIBRARY_LAYOUT]:
+            logger.warning(
+                f"Using inferred library layout of {inferred_library_layout} for {read_run[_.RUN_ACCESSION]} instead of metadata-provided {read_run[_.LIBRARY_LAYOUT]}."
+            )
+            run.metadata[
+                analyses.models.Run.CommonMetadataKeys.INFERRED_LIBRARY_LAYOUT
+            ] = inferred_library_layout
         run.save()
 
         run_accessions.append(run.first_accession)

--- a/workflows/ena_utils/webin_owner_utils.py
+++ b/workflows/ena_utils/webin_owner_utils.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+import ena.models
+
+
+def validate_and_set_webin_owner(
+    ena_study: ena.models.Study, webin_owner: Optional[str]
+) -> (ena.models.Study, bool):
+    """
+    Validate and set the webin owner on the provided ENA study.
+
+    Args:
+        ena_study: The ENA study object to set the webin owner on (if valid)
+        webin_owner: The webin owner string to validate and set
+
+    Returns:
+        The updated ENA study with potentially validated webin owner set, and a boolean indicating whether the webin owner was set
+
+    Raises:
+        AssertionError: If the webin owner doesn't start with 'Webin-'
+    """
+    if webin_owner:
+        webin_owner = webin_owner.title()
+        assert webin_owner.startswith("Webin-"), "Webin owner must start with 'Webin-'"
+        ena_study.webin_submitter = webin_owner
+        ena_study.save()  # fyi hooks propagate this to dependent models
+        return ena_study, True
+    return ena_study, False

--- a/workflows/fixtures/flowrun_input/conftest.py
+++ b/workflows/fixtures/flowrun_input/conftest.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+import pytest
+
+from workflows.prefect_utils.analyses_models_helpers import get_users_as_choices
+
+
+@pytest.fixture
+def biome_choices(top_level_biomes):
+    return Enum("BiomeChoices", {"root.engineered": "Root:Engineered"})
+
+
+@pytest.fixture
+def user_choices(admin_user):
+    return get_users_as_choices()

--- a/workflows/flows/analyse_study_tasks/copy_v6_pipeline_results.py
+++ b/workflows/flows/analyse_study_tasks/copy_v6_pipeline_results.py
@@ -28,7 +28,17 @@ def copy_v6_pipeline_results(analysis_accession: str):
     experiment_type_label = Analysis.ExperimentTypes(
         analysis.experiment_type
     ).label.lower()
-    target = f"{EMG_CONFIG.slurm.ftp_results_dir}/{accession_prefix_separated_dir_path(study.first_accession, -3)}/{accession_prefix_separated_dir_path(run.first_accession, -3)}/{analysis.pipeline_version}/{experiment_type_label}"
+    assert (
+        analysis.is_private == study.is_private == run.is_private
+    )  # Shouldn't ever be untrue, just a helper for the future
+
+    target_root = (
+        EMG_CONFIG.slurm.private_results_dir
+        if analysis.is_private
+        else EMG_CONFIG.slurm.ftp_results_dir
+    )
+
+    target = f"{target_root}/{accession_prefix_separated_dir_path(study.first_accession, -3)}/{accession_prefix_separated_dir_path(run.first_accession, -3)}/{analysis.pipeline_version}/{experiment_type_label}"
     print(
         f"Will copy results for {analysis_accession} from {analysis.results_dir} to {target}"
     )
@@ -57,9 +67,7 @@ def copy_v6_pipeline_results(analysis_accession: str):
         + ["--exclude=*"]
     )
     move_data(source, target, command)
-    analysis.external_results_dir = Path(target).relative_to(
-        EMG_CONFIG.slurm.ftp_results_dir
-    )
+    analysis.external_results_dir = Path(target).relative_to(target_root)
     print(
         f"Analysis {analysis} now has results at {analysis.external_results_dir} in {EMG_CONFIG.slurm.ftp_results_dir}"
     )
@@ -82,12 +90,15 @@ def copy_v6_study_summaries(study_accession: str):
         ]
     )
     source = trailing_slash_ensured_dir(study.results_dir)
-    target = f"{EMG_CONFIG.slurm.ftp_results_dir}/{accession_prefix_separated_dir_path(study.first_accession, -3)}/study-summaries/"
-    move_data(source, target, command, make_target=True)
-    study.external_results_dir = Path(target).parent.relative_to(
-        EMG_CONFIG.slurm.ftp_results_dir
+    target_root = (
+        EMG_CONFIG.slurm.private_results_dir
+        if study.is_private
+        else EMG_CONFIG.slurm.ftp_results_dir
     )
+    target = f"{target_root}/{accession_prefix_separated_dir_path(study.first_accession, -3)}/study-summaries/"
+    move_data(source, target, command, make_target=True)
+    study.external_results_dir = Path(target).parent.relative_to(target_root)
     study.save()
     print(
-        f"Study {study} now has results at {study.external_results_dir} in {EMG_CONFIG.slurm.ftp_results_dir}"
+        f"Study {study} now has results at {study.external_results_dir} in {target_root}"
     )

--- a/workflows/flows/analyse_study_tasks/create_analyses.py
+++ b/workflows/flows/analyse_study_tasks/create_analyses.py
@@ -45,6 +45,8 @@ def create_analyses(
             run=run,
             ena_study=study.ena_study,
             pipeline_version=pipeline,
+            is_private=run.is_private,
+            webin_submitter=run.webin_submitter,
         )
         if created:
             print(

--- a/workflows/flows/analysis_amplicon_study.py
+++ b/workflows/flows/analysis_amplicon_study.py
@@ -28,6 +28,7 @@ from workflows.ena_utils.ena_api_requests import (
     library_strategy_policy_to_filter,
     ENALibraryStrategyPolicy,
 )
+from workflows.ena_utils.webin_owner_utils import validate_and_set_webin_owner
 from workflows.flows.analyse_study_tasks.shared.study_summary import (
     merge_study_summaries,
     add_study_summaries_to_downloads,
@@ -68,6 +69,11 @@ def analysis_amplicon_study(study_accession: str):
     mgnify_study.refresh_from_db()
     logger.info(f"MGnify study is {mgnify_study.accession}: {mgnify_study.title}")
 
+    if mgnify_study.is_private:
+        logger.info(f"{mgnify_study} is a private study.")
+    else:
+        logger.info(f"{mgnify_study} is a public study.")
+
     read_runs = get_study_readruns_from_ena(
         ena_study.accession,
         limit=10000,
@@ -91,6 +97,10 @@ def analysis_amplicon_study(study_accession: str):
             ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
             description="Optionally treat read-runs with incorrect library strategy metadata as amplicon.",
         )
+        webin_owner: Optional[str] = Field(
+            None,
+            description="Webin ID of study owner, if data is private. Can be left as None, if public.",
+        )
 
     analyse_study_input: AnalyseStudyInput = suspend_flow_run(
         wait_for_input=AnalyseStudyInput.with_initial_data(
@@ -107,10 +117,23 @@ def analysis_amplicon_study(study_accession: str):
                 **Biome tagger**
                 Please select a Biome for the entire study \
                 [{ena_study.accession}: {ena_study.title}](https://www.ebi.ac.uk/ena/browser/view/{ena_study.accession}).
+
+                **Webin owner**
+                If the study is private, the webin account owner is needed so that the user can view the study they own.
                 """
             ),
         )
     )
+
+    ena_study, __ = validate_and_set_webin_owner(
+        ena_study, analyse_study_input.webin_owner
+    )
+    mgnify_study.refresh_from_db()
+
+    if mgnify_study.is_private and not mgnify_study.webin_submitter:
+        raise ValueError(
+            f"Study {mgnify_study.accession} is private, but no webin owner was provided."
+        )
 
     if (
         analyse_study_input.library_strategy_policy
@@ -145,13 +168,15 @@ def analysis_amplicon_study(study_accession: str):
         pipeline=analyses.models.Analysis.PipelineVersions.v6,
         ena_library_strategy_policy=analyse_study_input.library_strategy_policy,
     )
+    ena_study.save()  # just for safety, propagate privacy state/owner from study to new analyses etc.
+
     analyses_to_attempt = get_analyses_to_attempt(
         mgnify_study,
         for_experiment_type=analyses.models.WithExperimentTypeModel.ExperimentTypes.AMPLICON,
         ena_library_strategy_policy=analyse_study_input.library_strategy_policy,
     )
 
-    # Work on chunks of 20 readruns at a time
+    # Work on chunks of (e.g. 20) readruns at a time
     # Doing so means we don't use our entire cluster allocation for this study
     chunked_runs = chunk_list(
         analyses_to_attempt, EMG_CONFIG.amplicon_pipeline.samplesheet_chunk_size

--- a/workflows/flows/assemble_study.py
+++ b/workflows/flows/assemble_study.py
@@ -19,6 +19,7 @@ from workflows.ena_utils.ena_api_requests import (
     get_study_from_ena,
     get_study_readruns_from_ena,
 )
+from workflows.ena_utils.webin_owner_utils import validate_and_set_webin_owner
 from workflows.flows.assemble_study_tasks.assemble_samplesheets import (
     run_assembler_for_samplesheet,
 )
@@ -137,11 +138,8 @@ def assemble_study(
         )
     )
 
-    if assemble_study_input.webin_owner:
-        webin_owner = assemble_study_input.webin_owner.title()
-        assert webin_owner.startswith("Webin-")
-    else:
-        webin_owner = None
+    validate_and_set_webin_owner(ena_study, assemble_study_input.webin_owner)
+    mgnify_study.refresh_from_db()
 
     if assemble_study_input.watchers:
         add_study_watchers(mgnify_study, assemble_study_input.watchers)
@@ -164,10 +162,6 @@ def assemble_study(
         .first()
     )
     # assumes latest version...
-
-    if webin_owner:
-        ena_study.webin_submitter = webin_owner
-        ena_study.save()
 
     get_or_create_assemblies_for_runs(mgnify_study, read_runs)
     samplesheets = make_samplesheets_for_runs_to_assemble(mgnify_study, assembler)

--- a/workflows/flows/assemble_study_tasks/make_samplesheets.py
+++ b/workflows/flows/assemble_study_tasks/make_samplesheets.py
@@ -144,7 +144,7 @@ def make_samplesheets_for_runs_to_assemble(
     mgnify_study: analyses.models.Study,
     assembler: analyses.models.Assembler,
     chunk_size: int = 10,
-) -> [(Path, str)]:
+) -> list[tuple[Path, str]]:
 
     if mgnify_study.assemblies_reads.exclude(
         is_private=mgnify_study.is_private

--- a/workflows/tests/test_analysis_amplicon_study_flow.py
+++ b/workflows/tests/test_analysis_amplicon_study_flow.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-from enum import Enum
 from pathlib import Path
 from textwrap import dedent
 from typing import List, Optional
@@ -23,7 +22,7 @@ from workflows.flows.analyse_study_tasks.shared.study_summary import (
     STUDY_SUMMARY_TSV,
 )
 from workflows.flows.analysis_amplicon_study import analysis_amplicon_study
-from workflows.prefect_utils.analyses_models_helpers import get_users_as_choices
+from workflows.prefect_utils.pyslurm_patch import JobSubmitDescription
 from workflows.prefect_utils.testing_utils import (
     should_not_mock_httpx_requests_to_prefect_server,
     run_flow_and_capture_logs,
@@ -418,6 +417,19 @@ MockFileIsNotEmptyRule = FileRule(
 )
 
 
+@pytest.fixture
+def analysis_study_input_mocker(biome_choices, user_choices):
+    ## Pretend that a human resumed the flow with the biome picker, and then with the assembler selector.
+
+    class MockAnalyseStudyInput(BaseModel):
+        biome: biome_choices
+        webin_owner: Optional[str]
+        watchers: List[user_choices]
+        library_strategy_policy: ENALibraryStrategyPolicy
+
+    return MockAnalyseStudyInput
+
+
 @pytest.mark.httpx_mock(should_mock=should_not_mock_httpx_requests_to_prefect_server)
 @pytest.mark.django_db(transaction=True)
 @patch("workflows.flows.analyse_study_tasks.make_samplesheet_amplicon.queryset_hash")
@@ -439,6 +451,9 @@ def test_prefect_analyse_amplicon_flow(
     mock_suspend_flow_run,
     admin_user,
     top_level_biomes,
+    biome_choices,
+    user_choices,
+    analysis_study_input_mocker,
 ):
     """
     Test should create/get ENA and MGnify study into DB.
@@ -640,24 +655,17 @@ def test_prefect_analyse_amplicon_flow(
             )
         )
 
-        ## Pretend that a human resumed the flow with the biome picker.
-        BiomeChoices = Enum("BiomeChoices", {"root.engineered": "Root:Engineered"})
-        UserChoices = get_users_as_choices()
+    ## Pretend that a human resumed the flow with the biome picker.
+    def suspend_side_effect(wait_for_input=None):
+        if wait_for_input.__name__ == "AnalyseStudyInput":
+            return analysis_study_input_mocker(
+                biome=biome_choices["root.engineered"],
+                watchers=[user_choices[admin_user.username]],
+                library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                webin_owner=None,
+            )
 
-        class AnalyseStudyInput(BaseModel):
-            biome: BiomeChoices
-            watchers: List[UserChoices]
-            library_strategy_policy: Optional[ENALibraryStrategyPolicy]
-
-        def suspend_side_effect(wait_for_input=None):
-            if wait_for_input.__name__ == "AnalyseStudyInput":
-                return AnalyseStudyInput(
-                    biome=BiomeChoices["root.engineered"],
-                    watchers=[UserChoices[admin_user.username]],
-                    library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
-                )
-
-        mock_suspend_flow_run.side_effect = suspend_side_effect
+    mock_suspend_flow_run.side_effect = suspend_side_effect
 
     # RUN MAIN FLOW
     analysis_amplicon_study(study_accession=study_accession)
@@ -821,3 +829,309 @@ def test_prefect_analyse_amplicon_flow(
     study.refresh_from_db()
     assert len(study.downloads_as_objects) == 6
     assert study.features.has_v6_analyses
+
+
+@pytest.mark.httpx_mock(should_mock=should_not_mock_httpx_requests_to_prefect_server)
+@pytest.mark.django_db(transaction=True)
+@patch("workflows.flows.analyse_study_tasks.make_samplesheet_amplicon.queryset_hash")
+@patch(
+    "workflows.data_io_utils.mgnify_v6_utils.amplicon.FileIsNotEmptyRule",
+    MockFileIsNotEmptyRule,
+)
+@pytest.mark.parametrize(
+    "mock_suspend_flow_run", ["workflows.flows.analysis_amplicon_study"], indirect=True
+)
+def test_prefect_analyse_amplicon_flow_private_data(
+    mock_queryset_hash_for_amplicon,
+    prefect_harness,
+    httpx_mock,
+    mock_cluster_can_accept_jobs_yes,
+    mock_start_cluster_job,
+    mock_check_cluster_job_all_completed,
+    mock_suspend_flow_run,
+    admin_user,
+    top_level_biomes,
+    biome_choices,
+    user_choices,
+    analysis_study_input_mocker,
+):
+    """
+    Test should create/get ENA and MGnify study into DB.
+    Create analysis for amplicon runs and launch it with samplesheet.
+    One run has all results, one run failed
+    """
+
+    accession = "PRJNA398089"
+
+    httpx_mock.add_response(  # basic check response for whether study is private
+        url=f"{EMG_CONFIG.ena.portal_search_api}?"
+        f"result=study&"
+        f"query=%22%28study_accession%3D{accession}+OR+secondary_study_accession%3D{accession}%29%22&"
+        f"fields=study_accession&"
+        f"limit=&"
+        f"format=json&"
+        f"dataPortal=metagenome",
+        match_headers={
+            "Authorization": "Basic ZGNjX2Zha2U6bm90LWEtZGNjLXB3"
+        },  # dcc_fake:not-a-dcc-pw
+        json=[{"study_accession": accession}],
+    )
+
+    httpx_mock.add_response(
+        url=f"{EMG_CONFIG.ena.portal_search_api}?"
+        f"result=study&"
+        f"query=%22%28study_accession%3D{accession}+OR+secondary_study_accession%3D{accession}%29%22&"
+        f"fields=study_accession&"
+        f"limit=&"
+        f"format=json&"
+        f"dataPortal=metagenome",
+        match_headers={},  # public call should not find private study
+        json=[],
+    )
+
+    httpx_mock.add_response(
+        url=f"{EMG_CONFIG.ena.portal_search_api}?"
+        f"result=study&"
+        f"query=%22%28study_accession={accession}%20OR%20secondary_study_accession={accession}%29%22&"
+        f"limit=10&"
+        f"format=json&"
+        f"fields={','.join(EMG_CONFIG.ena.study_metadata_fields)}&"
+        f"dataPortal=metagenome",
+        match_headers={
+            "Authorization": "Basic ZGNjX2Zha2U6bm90LWEtZGNjLXB3"
+        },  # dcc_fake:not-a-dcc-pw
+        json=[  # study is available privately to dcc superuser
+            {
+                "study_title": "Metagenome of a wookie",
+                "secondary_study_accession": "SRP123456",
+                "study_accession": accession,
+            }
+        ],
+    )
+
+    mock_queryset_hash_for_amplicon.return_value = "abc123"
+
+    study_accession = "PRJNA398089"
+    amplicon_run_all_results = "SRR_all_results"
+    runs = [
+        amplicon_run_all_results,
+    ]
+
+    # mock ENA response
+    httpx_mock.add_response(
+        url=f"{EMG_CONFIG.ena.portal_search_api}?"
+        f"result=read_run"
+        f"&query=%22%28%28study_accession={study_accession}+OR+secondary_study_accession={study_accession}%29%20AND%20library_strategy=AMPLICON%29%22"
+        f"&limit=10000"
+        f"&format=json"
+        f"&fields=run_accession%2Csample_accession%2Csample_title%2Csecondary_sample_accession%2Cfastq_md5%2Cfastq_ftp%2Clibrary_layout%2Clibrary_strategy%2Clibrary_source%2Cscientific_name%2Chost_tax_id%2Chost_scientific_name%2Cinstrument_platform%2Cinstrument_model%2Clocation%2Clat%2Clon"
+        f"&dataPortal=metagenome",
+        match_headers={
+            "Authorization": "Basic ZGNjX2Zha2U6bm90LWEtZGNjLXB3"
+        },  # dcc_fake:not-a-dcc-pw
+        json=[
+            {
+                "sample_accession": "SAMN08514017",
+                "sample_title": "my data",
+                "secondary_sample_accession": "SAMN08514017",
+                "run_accession": amplicon_run_all_results,
+                "fastq_md5": "123;abc",
+                "fastq_ftp": f"ftp.sra.example.org/vol/fastq/{amplicon_run_all_results}/{amplicon_run_all_results}_1.fastq.gz;ftp.sra.example.org/vol/fastq/{amplicon_run_all_results}/{amplicon_run_all_results}_2.fastq.gz",
+                "library_layout": "PAIRED",
+                "library_strategy": "AMPLICON",
+                "library_source": "METAGENOMIC",
+                "scientific_name": "metagenome",
+                "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
+                "instrument_platform": "ILLUMINA",
+                "instrument_model": "Illumina MiSeq",
+                "lat": "52",
+                "lon": "0",
+                "location": "hinxton",
+            },
+        ],
+    )
+
+    # create fake results
+    amplicon_folder = Path(
+        f"{EMG_CONFIG.slurm.default_workdir}/{study_accession}_amplicon_v6/abc123"
+    )
+    amplicon_folder.mkdir(exist_ok=True, parents=True)
+
+    with open(
+        f"{amplicon_folder}/{EMG_CONFIG.amplicon_pipeline.completed_runs_csv}", "w"
+    ) as file:
+        file.write(f"{amplicon_run_all_results},all_results" + "\n")
+
+    # ------- results for completed runs with all results
+    generate_fake_pipeline_all_results(
+        f"{amplicon_folder}/{amplicon_run_all_results}", amplicon_run_all_results
+    )
+
+    ## Pretend that a human resumed the flow with the biome picker.
+    def suspend_side_effect(wait_for_input=None):
+        if wait_for_input.__name__ == "AnalyseStudyInput":
+            return analysis_study_input_mocker(
+                biome=biome_choices["root.engineered"],
+                watchers=[user_choices[admin_user.username]],
+                library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                webin_owner="webin-1",
+            )
+
+    mock_suspend_flow_run.side_effect = suspend_side_effect
+
+    # RUN MAIN FLOW
+    analysis_amplicon_study(study_accession=study_accession)
+
+    mock_start_cluster_job.assert_called()
+    mock_check_cluster_job_all_completed.assert_called()
+    mock_suspend_flow_run.assert_called()
+
+    assembly_samplesheet_table = Artifact.get("amplicon-v6-initial-sample-sheet")
+    assert assembly_samplesheet_table.type == "table"
+    table_data = json.loads(assembly_samplesheet_table.data)
+    assert len(table_data) == len(runs)
+
+    assert (
+        analyses.models.Analysis.objects.filter(
+            run__ena_accessions__contains=[amplicon_run_all_results]
+        ).count()
+        == 1
+    )
+
+    # check biome and watchers were set correctly
+    study = analyses.models.Study.objects.get_or_create_for_ena_study(study_accession)
+    assert study.biome.biome_name == "Engineered"
+    assert admin_user == study.watchers.first()
+
+    # check completed runs (all runs in completed list - might contain sanity check not passed as well)
+    assert study.analyses.filter(status__analysis_completed=True).count() == 1
+
+    assert (
+        study.analyses.filter(status__analysis_completed_reason="all_results").count()
+        == 1
+    )
+
+    analysis_which_should_have_taxonomies_imported: analyses.models.Analysis = (
+        analyses.models.Analysis.objects_and_annotations.get(
+            run__ena_accessions__contains=[amplicon_run_all_results]
+        )
+    )
+    assert (
+        analyses.models.Analysis.TAXONOMIES
+        in analysis_which_should_have_taxonomies_imported.annotations
+    )
+    assert (
+        analyses.models.Analysis.TaxonomySources.SSU.value
+        in analysis_which_should_have_taxonomies_imported.annotations[
+            analyses.models.Analysis.TAXONOMIES
+        ]
+    )
+    ssu = analysis_which_should_have_taxonomies_imported.annotations[
+        analyses.models.Analysis.TAXONOMIES
+    ][analyses.models.Analysis.TaxonomySources.SSU.value]
+    assert len(ssu) == 3
+    assert ssu[0]["organism"] == "sk__Bacteria;k__;p__Bacillota;c__Bacilli"
+
+    assert (
+        analysis_which_should_have_taxonomies_imported.KnownMetadataKeys.MARKER_GENE_SUMMARY
+        in analysis_which_should_have_taxonomies_imported.metadata
+    )
+    assert (
+        analysis_which_should_have_taxonomies_imported.metadata[
+            analysis_which_should_have_taxonomies_imported.KnownMetadataKeys.MARKER_GENE_SUMMARY
+        ]["closed_reference"]["marker_genes"]["SSU"]["Bacteria"]["read_count"]
+        == 1
+    )
+
+    workdir = Path(f"{EMG_CONFIG.slurm.default_workdir}/{study_accession}_v6")
+    assert workdir.is_dir()
+
+    assert study.external_results_dir == "SRP123/SRP123456"
+
+    Directory(
+        path=study.results_dir,
+        glob_rules=[
+            GlobHasFilesCountRule[10]
+        ],  # 5 for the samplesheet, same 5 for the "merge" (only 5 here, unlike public test, which has different hypervar regions)
+    )
+
+    with (workdir / "abc123_DADA2-SILVA_18S-V9_asv_study_summary.tsv").open(
+        "r"
+    ) as summary:
+        lines = summary.readlines()
+        assert lines[0] == "taxonomy\tSRR_all_results\n"  # one run (the one with ASVs)
+        assert "100" in lines[-1]
+        assert "g__Aeromicrobium" in lines[-1]
+
+    # manually remove the merged study summaries
+    for file in Path(study.results_dir).glob(f"{study.first_accession}*"):
+        file.unlink()
+
+    # test merging of study summaries again, with cleanup disabled
+    merge_study_summaries(
+        mgnify_study_accession=study.accession,
+        cleanup_partials=False,
+        analysis_type="amplicon",
+    )
+    Directory(
+        path=study.results_dir,
+        glob_rules=[
+            GlobHasFilesCountRule[
+                10
+            ],  # study ones generated, and partials left in place
+            GlobRule(
+                rule_name="All study level files are present",
+                glob_patten=f"{study.first_accession}*{STUDY_SUMMARY_TSV}",
+                test=lambda f: len(list(f)) == 5,
+            ),
+        ],
+    )
+
+    study.refresh_from_db()
+    assert len(study.downloads_as_objects) == 5
+
+    # test merging of study summaries again – expect default bludgeon should overwrite the existing ones
+    logged_run = run_flow_and_capture_logs(
+        merge_study_summaries,
+        mgnify_study_accession=study.accession,
+        cleanup_partials=True,
+        analysis_type="amplicon",
+    )
+    assert (
+        logged_run.logs.count(
+            f"Deleting {str(Path(study.results_dir) / study.first_accession)}"
+        )
+        == 5
+    )
+    Directory(
+        path=study.results_dir,
+        glob_rules=[
+            GlobHasFilesCountRule[5],  # partials deleted, just merged ones
+            GlobRule(
+                rule_name="All files are study level",
+                glob_patten=f"{study.first_accession}*{STUDY_SUMMARY_TSV}",
+                test=lambda f: len(list(f)) == 5,
+            ),
+        ],
+    )
+
+    study.refresh_from_db()
+    assert len(study.downloads_as_objects) == 5
+    assert study.features.has_v6_analyses
+
+    assert study.is_private
+    assert study.analyses.filter(is_private=True).count() == 1
+    assert study.analyses.exclude(is_private=True).count() == 0
+    assert study.runs.filter(is_private=True).count() == 1
+    assert study.runs.exclude(is_private=True).count() == 0
+
+    for cluster_job_start_call in mock_start_cluster_job.call_args_list:
+        args, kwargs = cluster_job_start_call
+
+        job_submit_description: JobSubmitDescription = kwargs.get(
+            "job_submit_description"
+        )
+        name: str = kwargs.get("name")
+        if name.startswith("Move"):
+            assert EMG_CONFIG.slurm.private_results_dir in job_submit_description.script

--- a/workflows/tests/test_analysis_amplicon_study_flow.py
+++ b/workflows/tests/test_analysis_amplicon_study_flow.py
@@ -1135,3 +1135,6 @@ def test_prefect_analyse_amplicon_flow_private_data(
         name: str = kwargs.get("name")
         if name.startswith("Move"):
             assert EMG_CONFIG.slurm.private_results_dir in job_submit_description.script
+            break
+    else:
+        assert False, "No Move cluster job submitted"

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -338,6 +338,82 @@ def test_get_study_readruns_from_ena(
                 "lon": "0",
                 "location": "hinxton",
             },
+            {
+                "run_accession": "RUN7",
+                "sample_accession": "SAMPLE7",
+                "sample_title": "sample title",
+                "secondary_sample_accession": "SAMP7",
+                "fastq_md5": "md5kjdndk",
+                "fastq_ftp": "fq_2.fastq.gz",
+                "library_layout": "PAIRED",
+                "library_strategy": "AMPLICON",
+                "library_source": "METAGENOMIC",
+                "scientific_name": "metagenome",
+                "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
+                "instrument_platform": "ILLUMINA",
+                "instrument_model": "Illumina MiSeq",
+                "lat": "52",
+                "lon": "0",
+                "location": "hinxton",
+            },
+            {
+                "run_accession": "RUN8",
+                "sample_accession": "SAMPLE8",
+                "sample_title": "sample title",
+                "secondary_sample_accession": "SAMP8",
+                "fastq_md5": "md5kjdndk",
+                "fastq_ftp": "fq_2.fastq.gz",
+                "library_layout": "SINGLE",
+                "library_strategy": "AMPLICON",
+                "library_source": "METAGENOMIC",
+                "scientific_name": "metagenome",
+                "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
+                "instrument_platform": "ILLUMINA",
+                "instrument_model": "Illumina MiSeq",
+                "lat": "52",
+                "lon": "0",
+                "location": "hinxton",
+            },
+            {
+                "run_accession": "RUN9",
+                "sample_accession": "SAMPLE9",
+                "sample_title": "sample title",
+                "secondary_sample_accession": "SAMP9",
+                "fastq_md5": "md5kjdndk",
+                "fastq_ftp": "",
+                "library_layout": "PAIRED",
+                "library_strategy": "AMPLICON",
+                "library_source": "METAGENOMIC",
+                "scientific_name": "metagenome",
+                "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
+                "instrument_platform": "ILLUMINA",
+                "instrument_model": "Illumina MiSeq",
+                "lat": "52",
+                "lon": "0",
+                "location": "hinxton",
+            },
+            {
+                "run_accession": "RUN10",
+                "sample_accession": "SAMPLE10",
+                "sample_title": "sample title",
+                "secondary_sample_accession": "SAMP10",
+                "fastq_md5": "md5kjdndk",
+                "fastq_ftp": "fq.fastq.gz;fq_2.fastq.gz;fq_1.fastq.gz",
+                "library_layout": "PAIRED",
+                "library_strategy": "AMPLICON",
+                "library_source": "METAGENOMIC",
+                "scientific_name": "metagenome",
+                "host_tax_id": "7460",
+                "host_scientific_name": "Apis mellifera",
+                "instrument_platform": "ILLUMINA",
+                "instrument_model": "Illumina MiSeq",
+                "lat": "52",
+                "lon": "0",
+                "location": "hinxton",
+            },
         ],
     )
     get_study_readruns_from_ena(study_accession, limit=10)
@@ -359,12 +435,12 @@ def test_get_study_readruns_from_ena(
     # incorrect library_layout single
     assert (
         analyses.models.Run.objects.filter(ena_accessions__contains=["RUN4"]).count()
-        == 0
+        == 1
     )
     # incorrect library_layout paired
     assert (
         analyses.models.Run.objects.filter(ena_accessions__contains=["RUN5"]).count()
-        == 0
+        == 1
     )
     # should return only 2 fq files in correct order
     assert (
@@ -378,6 +454,32 @@ def test_get_study_readruns_from_ena(
         and "_2" in run.metadata["fastq_ftps"][1]
     )
     assert run.metadata["host_tax_id"] == "7460"
+    # incorrect: only "_2" and PAIRED
+    assert (
+        analyses.models.Run.objects.filter(ena_accessions__contains=["RUN7"]).count()
+        == 0
+    )
+    # incorrect: only "_2" and SINGLE
+    assert (
+        analyses.models.Run.objects.filter(ena_accessions__contains=["RUN8"]).count()
+        == 0
+    )
+    # no fastqs found
+    assert (
+        analyses.models.Run.objects.filter(ena_accessions__contains=["RUN9"]).count()
+        == 0
+    )
+    # should return only 2 fq files in correct order [alphabetical order shouldn't affect runs anymore]
+    assert (
+        analyses.models.Run.objects.filter(ena_accessions__contains=["RUN10"]).count()
+        == 1
+    )
+    run = analyses.models.Run.objects.get(ena_accessions__contains=["RUN10"])
+    assert (
+        len(run.metadata["fastq_ftps"]) == 2
+        and "_1" in run.metadata["fastq_ftps"][0]
+        and "_2" in run.metadata["fastq_ftps"][1]
+    )
 
     httpx_mock.add_response(
         url=f"{EMG_CONFIG.ena.portal_search_api}?result=read_run&query=%22%28study_accession%3D{study_accession}+OR+secondary_study_accession%3D{study_accession}%29%22"


### PR DESCRIPTION
This PR:
- adds support for private (i.e. pre-release) ENA data in Amplicon V6 flow
  - prefect user is asked for a webin account if data is private
  - analysis results are moved to private files area instead of public transfer services area
  - minor refactoring of fixtures/utils used for private data support in existing mi-assembler flow

TODO:
- just base branch to `main` after #67 is merged