### PR TITLE
Webin-cli improvements

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -93,11 +93,14 @@ fileignoreconfig:
   allowed_patterns: [key, InstrumentPlatformKeys]
 
 - filename: workflows/flows/upload_assembly.py
-  allowed_patterns: ["-password='{password}'"]
+  checksum: f82f92058dabd50b9b6caf557d4eadae227ec4f6a0233135653251c20cf3c64b
 
 - filename: workflows/prefect_utils/env_context.py
   checksum: 8f5e11c7e0038bc4a648dc61ec657a679356857f77e557f744e2dd769ad88def
   ignore_detectors: [filename]
+
+- filename: workflows/tests/test_cli_command_utils.py
+  checksum: 3f541206fc17c825cd777704cfce875305fd313475553b95ff764b0f4a0c8f92
 
 - filename: workflows/tests/test_env_context.py
   checksum: 6d3d6b0c08bc5c564a2b7f79c21fb3f10244dc9b770eac0d2344766bdb358fa0

--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -113,6 +113,7 @@ class WebinConfig(BaseModel):
     dcc_password: str = None
     submitting_center_name: str = "EMG"
     webin_cli_executor: str = "/usr/bin/webin-cli/webin-cli.jar"
+    aspera_ascp_executor: str = None
     broker_prefix: str = "mg-"
     broker_password: str = None
     webin_cli_retries: int = 6

--- a/emgapiv2/settings_test.py
+++ b/emgapiv2/settings_test.py
@@ -7,6 +7,7 @@ EMG_CONFIG.webin.emg_webin_account = "webin-fake"
 EMG_CONFIG.webin.emg_webin_password = "not-a-pw"
 EMG_CONFIG.webin.dcc_account = "dcc_fake"
 EMG_CONFIG.webin.dcc_password = "not-a-dcc-pw"
+EMG_CONFIG.webin.aspera_ascp_executor = "/not/bin/aspera/ascp"
 EMG_CONFIG.ena.portal_search_api_max_retries = 0  # failfast in unit tests
 EMG_CONFIG.ena.portal_search_api_retry_delay_seconds = 1
 EMG_CONFIG.amplicon_pipeline.allow_non_insdc_run_names = True

--- a/emgapiv2/test_utils.py
+++ b/emgapiv2/test_utils.py
@@ -68,6 +68,18 @@ def test_log_masking():
     """
     )
 
+    script = "./run-command subcommand -flag=okay -password verysecret"
+    assert (
+        mask_sensitive_data(script)
+        == "./run-command subcommand -flag=okay -password *****"
+    )
+
+    script = "./run-command subcommand -flag=okay -password 'verysecret'"
+    assert (
+        mask_sensitive_data(script)
+        == "./run-command subcommand -flag=okay -password '*****'"
+    )
+
 
 @pytest.mark.django_db
 def test_json_field_with_schema():

--- a/workflows/ena_utils/webincli_logback.xml
+++ b/workflows/ena_utils/webincli_logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    {# debug level logging for webin-cli #}
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/workflows/tests/test_cli_command_utils.py
+++ b/workflows/tests/test_cli_command_utils.py
@@ -1,4 +1,8 @@
+from importlib.resources import files
+
+from activate_django_first import EMG_CONFIG
 from workflows.prefect_utils.build_cli_command import cli_command
+from workflows import ena_utils
 
 
 def test_cli_command_generator():
@@ -28,3 +32,37 @@ def test_cli_command_generator():
 
     command = cli_command(["echo", ("--greeting", "hello", "-world")])
     assert command == "echo --greeting hello -world"
+
+
+def test_cli_command_generator_realistic():
+    # More realistic test with complicated completions for a webin-cli command
+
+    xms = int(EMG_CONFIG.assembler.assembly_uploader_mem_gb / 2)
+    xmx = int(EMG_CONFIG.assembler.assembly_uploader_mem_gb)
+
+    logback_config = files(ena_utils) / "webincli_logback.xml"
+
+    manifest = "my-files/manifest.txt"
+    username = "Webin-me"
+    password = "not=a&pw"
+    dry_run = False
+
+    command = cli_command(
+        [
+            ("java", f"-Dlogback.configurationFile={logback_config}"),
+            f"-Xms{xms}g",
+            f"-Xmx{xmx}g",
+            ("-jar", EMG_CONFIG.webin.webin_cli_executor),
+            ("-context", "genome"),
+            ("-manifest", manifest),
+            ("-userName", username),
+            ("-password", password),
+            EMG_CONFIG.webin.aspera_ascp_executor and "-ascp",
+            dry_run and "-test -validate",
+            not dry_run and "-submit",
+        ]
+    )
+    assert (
+        command
+        == "java -Dlogback.configurationFile=/app/workflows/ena_utils/webincli_logback.xml -Xms2g -Xmx4g -jar /usr/bin/webin-cli/webin-cli.jar -context genome -manifest my-files/manifest.txt -userName Webin-me -password 'not=a&pw' -ascp -submit"
+    )


### PR DESCRIPTION
This PR:
- adds a debug logging config for webin-cli to better understand failure cases
- adds (optional) Aspera support, where `ascp` is available. NB `ascp` must be available on PATH.