### PR TITLE
Add fallback to ena data portal if metagenome data portal returns no data

### DIFF
--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -133,7 +133,10 @@ class WebinConfig(BaseModel):
 
 class ENAConfig(BaseModel):
     portal_search_api: AnyHttpUrl = "https://www.ebi.ac.uk/ena/portal/api/search"
-    portal_search_api_default_data_portals: list[ENAPortalDataPortal] = [ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA]
+    portal_search_api_default_data_portals: list[ENAPortalDataPortal] = [
+        ENAPortalDataPortal.METAGENOME,
+        ENAPortalDataPortal.ENA,
+    ]
     portal_search_api_max_retries: int = 4
     portal_search_api_retry_delay_seconds: int = 15
     browser_view_url_prefix: AnyHttpUrl = "https://www.ebi.ac.uk/ena/browser/view"

--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -6,6 +6,8 @@ from pydantic import AnyHttpUrl, BaseModel, Field
 from pydantic.networks import MongoDsn, MySQLDsn
 from pydantic_settings import BaseSettings
 
+from workflows.ena_utils.abstract import ENAPortalDataPortal
+
 
 class SlurmConfig(BaseModel):
     default_job_status_checks_limit: int = 10
@@ -131,6 +133,7 @@ class WebinConfig(BaseModel):
 
 class ENAConfig(BaseModel):
     portal_search_api: AnyHttpUrl = "https://www.ebi.ac.uk/ena/portal/api/search"
+    portal_search_api_default_data_portals: list[ENAPortalDataPortal] = [ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA]
     portal_search_api_max_retries: int = 4
     portal_search_api_retry_delay_seconds: int = 15
     browser_view_url_prefix: AnyHttpUrl = "https://www.ebi.ac.uk/ena/browser/view"

--- a/emgapiv2/settings_test.py
+++ b/emgapiv2/settings_test.py
@@ -1,6 +1,7 @@
 import tempfile
 
 from .settings import *
+from workflows.ena_utils.abstract import ENAPortalDataPortal
 
 EMG_CONFIG.slurm.default_workdir = tempfile.gettempdir()
 EMG_CONFIG.webin.emg_webin_account = "webin-fake"
@@ -9,6 +10,7 @@ EMG_CONFIG.webin.dcc_account = "dcc_fake"
 EMG_CONFIG.webin.dcc_password = "not-a-dcc-pw"
 EMG_CONFIG.webin.aspera_ascp_executor = "/not/bin/aspera/ascp"
 EMG_CONFIG.webin.auth_endpoint = "http://fake-auth.example.com/auth"
+EMG_CONFIG.ena.portal_search_api_default_data_portals = [ENAPortalDataPortal.METAGENOME]
 EMG_CONFIG.ena.portal_search_api_max_retries = 0  # failfast in unit tests
 EMG_CONFIG.ena.portal_search_api_retry_delay_seconds = 1
 EMG_CONFIG.amplicon_pipeline.allow_non_insdc_run_names = True

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -89,7 +89,6 @@ def get_study_from_ena(accession: str, limit: int = 10) -> ena.models.Study:
         limit=limit,
         query=ENAStudyQuery(study_accession=accession)
         | ENAStudyQuery(secondary_study_accession=accession),
-        data_portal=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get(auth=ena_auth)
 
     s = portal[0]
@@ -326,7 +325,6 @@ def get_study_readruns_from_ena(
         ],
         limit=limit,
         query=query,
-        data_portal=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get(auth=ena_auth, raise_on_empty=raise_on_empty)
 
     run_accessions = []
@@ -391,7 +389,6 @@ def is_study_available(accession: str, auth: Optional[Type[Auth]] = None) -> boo
             ),
             format="json",
             fields=[ENAStudyFields.STUDY_ACCESSION],
-            data_portal=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
         ).get(auth=auth)
     except ENAAvailabilityException as e:
         logger.info(f"Looks like an error-free empty response from ENA: {e}")
@@ -511,7 +508,6 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
         limit=limit,
         query=ENAAnalysisQuery(study_accession=accession)
         | ENAAnalysisQuery(secondary_study_accession=accession),
-        data_portal=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get(auth=ena_auth)
 
     # read-runs may exist in same study as the assemblies

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -89,7 +89,7 @@ def get_study_from_ena(accession: str, limit: int = 10) -> ena.models.Study:
         limit=limit,
         query=ENAStudyQuery(study_accession=accession)
         | ENAStudyQuery(secondary_study_accession=accession),
-        data_portal=ENAPortalDataPortal.METAGENOME,
+        data_portal=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get(auth=ena_auth)
 
     s = portal[0]
@@ -326,7 +326,7 @@ def get_study_readruns_from_ena(
         ],
         limit=limit,
         query=query,
-        data_portal=ENAPortalDataPortal.METAGENOME,
+        data_portal=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get(auth=ena_auth, raise_on_empty=raise_on_empty)
 
     run_accessions = []
@@ -391,7 +391,7 @@ def is_study_available(accession: str, auth: Optional[Type[Auth]] = None) -> boo
             ),
             format="json",
             fields=[ENAStudyFields.STUDY_ACCESSION],
-            data_portal=ENAPortalDataPortal.METAGENOME,
+            data_portal=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
         ).get(auth=auth)
     except ENAAvailabilityException as e:
         logger.info(f"Looks like an error-free empty response from ENA: {e}")
@@ -511,7 +511,7 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
         limit=limit,
         query=ENAAnalysisQuery(study_accession=accession)
         | ENAAnalysisQuery(secondary_study_accession=accession),
-        data_portal=ENAPortalDataPortal.METAGENOME,
+        data_portal=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get(auth=ena_auth)
 
     # read-runs may exist in same study as the assemblies

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -12,7 +12,7 @@ import analyses.models
 import ena.models
 from emgapiv2.dict_utils import some
 from emgapiv2.enum_utils import FutureStrEnum
-from workflows.ena_utils.abstract import ENAPortalResultType, ENAPortalDataPortal
+from workflows.ena_utils.abstract import ENAPortalResultType
 from workflows.ena_utils.analysis import ENAAnalysisFields, ENAAnalysisQuery
 from workflows.ena_utils.ena_accession_matching import (
     extract_all_accessions,

--- a/workflows/ena_utils/requestors.py
+++ b/workflows/ena_utils/requestors.py
@@ -35,7 +35,7 @@ class ENAAPIRequest(BaseModel):
     limit: Optional[int] = Field(None, description="Max number of results to return")
     format: Literal["tsv", "json"] = Field("json")
     data_portals: list[ENAPortalDataPortal] = Field(
-        [ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
+        EMG_CONFIG.ena.portal_search_api_default_data_portals,
         description="The ENA Portal API data portal to query.",
         serialization_alias="dataPortal",
     )

--- a/workflows/ena_utils/requestors.py
+++ b/workflows/ena_utils/requestors.py
@@ -91,6 +91,10 @@ class ENAAPIRequest(BaseModel):
     def serialize_result_type(self, result: ENAPortalResultType):
         return result.value
 
+    @field_serializer("data_portals")
+    def serialize_data_portal(self, data_portals: list[ENAPortalDataPortal]):
+        return " or ".join([portal.value for portal in data_portals])
+
     def _parse_response(self, response: httpx.Response, raise_on_empty: bool = True):
         if self.format == "json":
             try:

--- a/workflows/ena_utils/requestors.py
+++ b/workflows/ena_utils/requestors.py
@@ -92,7 +92,7 @@ class ENAAPIRequest(BaseModel):
         return result.value
 
     @field_serializer("data_portals")
-    def serialize_data_portal(self, data_portals: list[ENAPortalDataPortal]):
+    def serialize_data_portals(self, data_portals: list[ENAPortalDataPortal]):
         return " or ".join([portal.value for portal in data_portals])
 
     def _parse_response(self, response: httpx.Response, raise_on_empty: bool = True):

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -130,11 +130,11 @@ def test_get_study_only_available_in_ena_portal(httpx_mock, prefect_harness):
     """
     sec_study_accession = "SRP0009034"
     httpx_mock.add_response(
-        url=f"{EMG_CONFIG.ena.portal_search_api}?result=study&query=%22%28study_accession={sec_study_accession}%20OR%20secondary_study_accession={sec_study_accession}%29%22&limit=10&format=json&fields={','.join(EMG_CONFIG.ena.study_metadata_fields)}&dataPortal=metagenome",
+        url=f"{EMG_CONFIG.ena.portal_search_api}?result=study&query=%22secondary_study_accession={sec_study_accession}%22&limit=10&format=json&fields={','.join(EMG_CONFIG.ena.study_metadata_fields)}&dataPortal=metagenome",
         json=[],
     )
     httpx_mock.add_response(
-        url=f"{EMG_CONFIG.ena.portal_search_api}?result=study&query=%22%28study_accession={sec_study_accession}%20OR%20secondary_study_accession={sec_study_accession}%29%22&limit=10&format=json&fields={','.join(EMG_CONFIG.ena.study_metadata_fields)}&dataPortal=ena",
+        url=f"{EMG_CONFIG.ena.portal_search_api}?result=study&query=%22secondary_study_accession={sec_study_accession}%22&limit=10&format=json&fields={','.join(EMG_CONFIG.ena.study_metadata_fields)}&dataPortal=ena",
         json=[
             {
                 "study_title": "I wanted to be normal, but they put me in ena portal",
@@ -145,7 +145,7 @@ def test_get_study_only_available_in_ena_portal(httpx_mock, prefect_harness):
     )
     request = ENAAPIRequest(
         result=ENAPortalResultType.STUDY,
-        query=ENAStudyQuery(study_accession=sec_study_accession),
+        query=ENAStudyQuery(secondary_study_accession=sec_study_accession),
         fields=EMG_CONFIG.ena.study_metadata_fields,
         data_portals=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get()

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -790,6 +790,7 @@ def test_ena_api_query_maker(httpx_mock):
         "limit": 10,
         "format": "json",
         "result": "study",
+        "dataPortal": "metagenome",
     }
 
     # calling API

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -144,7 +144,9 @@ def test_get_study_only_available_in_ena_portal(httpx_mock, prefect_harness):
         ],
     )
     request = ENAAPIRequest(
+        result=ENAPortalResultType.STUDY,
         query=ENAStudyQuery(study_accession=sec_study_accession),
+        fields=EMG_CONFIG.ena.study_metadata_fields,
         data_portals=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get()
     assert "I wanted to be normal" in request.json()["study_title"]

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -757,7 +757,6 @@ def test_ena_api_query_maker(httpx_mock):
         "limit": 10,
         "format": "json",
         "result": "study",
-        "dataPortal": "metagenome",
     }
 
     # calling API

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -145,8 +145,11 @@ def test_get_study_only_available_in_ena_portal(httpx_mock, prefect_harness):
     )
     request = ENAAPIRequest(
         result=ENAPortalResultType.STUDY,
+        limit=10,
         query=ENAStudyQuery(secondary_study_accession=sec_study_accession),
-        fields=EMG_CONFIG.ena.study_metadata_fields,
+        fields=[
+            ENAStudyFields[f.upper()] for f in EMG_CONFIG.ena.study_metadata_fields
+        ],
         data_portals=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get()
     assert "I wanted to be normal" in request.json()["study_title"]

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -122,7 +122,7 @@ def test_get_study_from_ena_use_secondary_as_primary(httpx_mock, prefect_harness
     assert len(created_study.additional_accessions) == 1
 
 
-@pytest.mark.httpx_mock(should_mock=should_not_mock_httpx_requests_to_prefect_server)
+@pytest.mark.httpx_mock
 @pytest.mark.django_db(transaction=True)
 def test_get_study_only_available_in_ena_portal(httpx_mock, prefect_harness):
     """

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -145,7 +145,7 @@ def test_get_study_only_available_in_ena_portal(httpx_mock, prefect_harness):
     )
     request = ENAAPIRequest(
         query=ENAStudyQuery(study_accession=sec_study_accession),
-        data_portals= [ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
+        data_portals=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get()
     assert "I wanted to be normal" in request.json()["study_title"]
 

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -152,7 +152,7 @@ def test_get_study_only_available_in_ena_portal(httpx_mock, prefect_harness):
         ],
         data_portals=[ENAPortalDataPortal.METAGENOME, ENAPortalDataPortal.ENA],
     ).get()
-    assert "I wanted to be normal" in request.json()["study_title"]
+    assert "I wanted to be normal" in request[0]["study_title"]
 
 
 @pytest.mark.httpx_mock(should_mock=should_not_mock_httpx_requests_to_prefect_server)
@@ -781,7 +781,7 @@ def test_ena_api_query_maker(httpx_mock):
             ENAStudyFields.SECONDARY_STUDY_ACCESSION,
         ],
         limit=10,
-        data_portal=ENAPortalDataPortal.METAGENOME,
+        data_portals=[ENAPortalDataPortal.METAGENOME],
     )
 
     assert request.model_dump(by_alias=True) == {


### PR DESCRIPTION
- ENAAPIRequest.get() method updated to make multiple requests until first non-empty response
- default portals are now set in config 
- new test