### PR TITLE
Gracefully handle completely failed amplicon sheets

### DIFF
--- a/workflows/flows/analyse_study_tasks/run_amplicon_pipeline_via_samplesheet.py
+++ b/workflows/flows/analyse_study_tasks/run_amplicon_pipeline_via_samplesheet.py
@@ -99,6 +99,13 @@ def run_amplicon_pipeline_via_samplesheet(
         # assume that if job finished, all finished... set statuses
         set_post_analysis_states(amplicon_current_outdir, amplicon_analyses)
         import_completed_analyses(amplicon_current_outdir, amplicon_analyses)
+        for analysis in amplicon_analyses:
+            analysis.refresh_from_db()
+            if analysis.status[analysis.AnalysisStates.ANALYSIS_COMPLETED]:
+                break
+        else:
+            print("Not creating summaries because ALL analyses of samplesheet failed")
+            return
         generate_markergene_summary_for_pipeline_run(
             mgnify_study_accession=mgnify_study.accession,
             pipeline_outdir=amplicon_current_outdir,


### PR DESCRIPTION
If **no** amplicon analysis runs complete successfully, do not try (and therefore fail) to run summary generator commands. Instead, exit happily.