### PR TITLE
Remove nextflow run names from pipeline jobs

### DIFF
--- a/workflows/flows/analyse_study_tasks/run_amplicon_pipeline_via_samplesheet.py
+++ b/workflows/flows/analyse_study_tasks/run_amplicon_pipeline_via_samplesheet.py
@@ -70,7 +70,6 @@ def run_amplicon_pipeline_via_samplesheet(
             ("--input", samplesheet),
             ("--outdir", amplicon_current_outdir),
             EMG_CONFIG.slurm.use_nextflow_tower and "-with-tower",
-            ("-name", f"ampl-v6-sheet-{slugify(samplesheet)[-10:]}"),
             ("-ansi-log", "false"),
         ]
     )

--- a/workflows/flows/assemble_study_tasks/assemble_samplesheets.py
+++ b/workflows/flows/assemble_study_tasks/assemble_samplesheets.py
@@ -230,10 +230,6 @@ def run_assembler_for_samplesheet(
             mgnify_study.is_private and "--private_study",
             ("--outdir", miassembler_outdir),
             EMG_CONFIG.slurm.use_nextflow_tower and "-with-tower",
-            (
-                "-name",
-                f"miassembler-samplesheet-{file_path_shortener(samplesheet_csv, 1, 15, True)}",
-            ),
         ]
     )
 

--- a/workflows/flows/realistic_example.py
+++ b/workflows/flows/realistic_example.py
@@ -129,7 +129,6 @@ def realistic_example(accession: str):
                 command=(
                     f"nextflow run {EMG_CONFIG.slurm.pipelines_root_dir}/download_read_runs.nf "
                     f"-resume "
-                    f"-name fetch-read-runs-{study.accession}-{sample_accession} "
                     f"--sample {sample_accession} "
                     f"-ansi-log false "  # otherwise the logs in prefect/django are full of control characters
                     f"-with-trace trace-{sample_accession}.txt"

--- a/workflows/nextflow_utils/tower.py
+++ b/workflows/nextflow_utils/tower.py
@@ -1,30 +1,8 @@
-import logging
-
 from django.conf import settings
 from pydantic_core import Url
 
 
-def maybe_get_nextflow_tower_browse_url(command: str) -> Url | None:
-    """
-    If the command looks like a nextflow run with tower enabled and an explicitly defined name,
-    return the Nextflow Tower URL for it (to be browsed).
-    :param command: A command-line instruction e.g. nextflow run....
-    :return: A Nextflow Tower / Seqera Platform URL, or None
-    """
-    if "nextflow run" in command and "-tower" in command:
-        if "-name" in command:
-            try:
-                wf_name = command.split("-name")[1].strip().split(" ")[0]
-            except KeyError:
-                logging.warning(
-                    f"Could not determine nextflow workflow run name from {command}"
-                )
-            else:
-                return Url(
-                    f"https://cloud.seqera.io/orgs/{settings.EMG_CONFIG.slurm.nextflow_tower_org}/workspaces/{settings.EMG_CONFIG.slurm.nextflow_tower_workspace}/watch?search={wf_name}"
-                )
-        else:
-            # No explicit name, just link to tower watch listing page
-            return Url(
-                f"https://cloud.seqera.io/orgs/{settings.EMG_CONFIG.slurm.nextflow_tower_org}/workspaces/{settings.EMG_CONFIG.slurm.nextflow_tower_workspace}/watch"
-            )
+def get_nextflow_tower_url() -> Url | None:
+    return Url(
+        f"https://cloud.seqera.io/orgs/{settings.EMG_CONFIG.slurm.nextflow_tower_org}/workspaces/{settings.EMG_CONFIG.slurm.nextflow_tower_workspace}/watch"
+    )

--- a/workflows/prefect_utils/slurm_flow.py
+++ b/workflows/prefect_utils/slurm_flow.py
@@ -16,7 +16,7 @@ from prefect.runtime import flow_run
 
 from emgapiv2.log_utils import mask_sensitive_data as safe
 from workflows.models import OrchestratedClusterJob
-from workflows.nextflow_utils.tower import maybe_get_nextflow_tower_browse_url
+from workflows.nextflow_utils.tower import get_nextflow_tower_url
 from workflows.nextflow_utils.trace import maybe_get_nextflow_trace_df
 from workflows.prefect_utils.slurm_limits import delay_until_cluster_has_space
 from workflows.prefect_utils.slurm_policies import (
@@ -270,7 +270,7 @@ def start_or_attach_cluster_job(
         job_submit_description=job_submit_description,
     )
 
-    nf_link = maybe_get_nextflow_tower_browse_url(command)
+    nf_link = get_nextflow_tower_url()
     nf_link_markdown = f"[Watch Nextflow Workflow]({nf_link})" if nf_link else ""
 
     ocj = OrchestratedClusterJob.objects.create(


### PR DESCRIPTION
We run `nextflow run -resume..` for most pipelines so that on a partial failure, nextflow can continue with a retry. However specififying `-name ...` as well, only works IFF the command and inputs do not change before the retry. This causes fragility when samplesheets change, or the pipeline or orchestration changes during longer pipeline runs. Without a `-name`, nextflow will figure out its own naming and cache busting.

This PR removes the naming. The only downsides of this are:
1. it is harder to find corresponding runs in seqera platform / tower (you now need to look in the job logs for the URL)
2. it is harder to determine what a given job is in slurm cluster stats