### PR TITLE
Specify assembler workdir

### DIFF
--- a/workflows/flows/assemble_study_tasks/assemble_samplesheets.py
+++ b/workflows/flows/assemble_study_tasks/assemble_samplesheets.py
@@ -229,6 +229,7 @@ def run_assembler_for_samplesheet(
             ("--samplesheet", samplesheet_csv),
             mgnify_study.is_private and "--private_study",
             ("--outdir", miassembler_outdir),
+            ("--workdir", miassembler_outdir),
             EMG_CONFIG.slurm.use_nextflow_tower and "-with-tower",
         ]
     )


### PR DESCRIPTION
Now pipeline uses default workdir from config. I think it was outdir in the past.. I've changed only assembly yet to give it a try