### PR TITLE
fix definition of assembled_runs_csv

### DIFF
--- a/workflows/flows/assemble_study_tasks/assemble_samplesheets.py
+++ b/workflows/flows/assemble_study_tasks/assemble_samplesheets.py
@@ -218,6 +218,7 @@ def run_assembler_for_samplesheet(
         / f"{mgnify_study.ena_study.accession}_miassembler"
         / samplesheet_hash
     )
+    assembled_runs_csv = miassembler_outdir / Path("assembled_runs.csv")
 
     command = cli_command(
         [
@@ -269,7 +270,6 @@ def run_assembler_for_samplesheet(
                     run_accession, fail_reason = row
                     qc_failed_runs[run_accession] = fail_reason
 
-        assembled_runs_csv = miassembler_outdir / Path("assembled_runs.csv")
         assembled_runs = set()
 
         if not assembled_runs_csv.is_file():


### PR DESCRIPTION
Should fix:
```
 File "/nfs/production/rdf/metagenomics/jenkins-slurm/dev-prefect-agent/venv/lib/python3.12/site-packages/prefect/utilities/callables.py", line 210, in call_with_parameters
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/nfs/production/rdf/metagenomics/jenkins-slurm/dev-prefect-agent/workflows/flows/assemble_study_tasks/assemble_samplesheets.py", line 314, in run_assembler_for_samplesheet
    if assembled_runs_csv.is_file():
       ^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'assembled_runs_csv' where it is not associated with a value
```