### PR TITLE
Removed RawR pipeline profile, not needed any more

### DIFF
--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -104,7 +104,6 @@ class RawReadsPipelineConfig(BaseModel):
         "master"  # branch or commit of ebi-metagenomics/raw-reads-analysis-pipeline
     )
     rawreads_pipeline_config_file: str = "/nfs/production/nextflow-configs/codon.config"
-    rawreads_pipeline_nf_profile: str = "codon"
     samplesheet_chunk_size: int = 50
     # results stats
     completed_runs_csv: str = "qc_passed_runs.csv"

--- a/workflows/flows/analyse_study_tasks/run_rawreads_pipeline_via_samplesheet.py
+++ b/workflows/flows/analyse_study_tasks/run_rawreads_pipeline_via_samplesheet.py
@@ -63,7 +63,6 @@ def run_rawreads_pipeline_via_samplesheet(
             ("-r", EMG_CONFIG.rawreads_pipeline.rawreads_pipeline_git_revision),
             "-latest",  # Pull changes from GitHub
             ("-config", EMG_CONFIG.rawreads_pipeline.rawreads_pipeline_config_file),
-            ("-profile", EMG_CONFIG.rawreads_pipeline.rawreads_pipeline_nf_profile),
             "-resume",
             ("--samplesheet", samplesheet),
             ("--outdir", rawreads_current_outdir),


### PR DESCRIPTION
There is now no codon profile, all codon parameters are either pipeline defaults or set in codon config from nextflow-pipelines-config repo