### PR TITLE
Fix RecursionError in custom PostgreSQL backend - EMG-9665

### DIFF
--- a/emgapiv2/db_backend/postgresql/base.py
+++ b/emgapiv2/db_backend/postgresql/base.py
@@ -16,6 +16,11 @@ class DatabaseWrapper(base.DatabaseWrapper):
     def ensure_connection(self) -> None:
         """
         Guarantee a live connection, closing stale or obsolete connections first.
+
+        Only checks for stale/obsolete connections when one already exists, to avoid
+        a recursion: ``get_autocommit()`` (called inside ``close_if_unusable_or_obsolete``)
+        would otherwise call ``ensure_connection()`` again when no connection is open.
         """
-        self.close_if_unusable_or_obsolete()
+        if self.connection is not None:
+            self.close_if_unusable_or_obsolete()
         super().ensure_connection()

--- a/emgapiv2/test_db_backend.py
+++ b/emgapiv2/test_db_backend.py
@@ -7,8 +7,32 @@ def make_wrapper():
     return DatabaseWrapper.__new__(DatabaseWrapper)
 
 
-def test_ensure_connection_calls_health_check_before_super():
+def test_ensure_connection_skips_health_check_when_no_connection():
+    """When self.connection is None there is nothing stale to close, and
+    calling close_if_unusable_or_obsolete would recurse via get_autocommit."""
     wrapper = make_wrapper()
+    wrapper.connection = None
+    call_order = []
+
+    with (
+        patch.object(
+            DatabaseWrapper,
+            "close_if_unusable_or_obsolete",
+            side_effect=lambda: call_order.append("health_check"),
+        ),
+        patch(
+            "django.db.backends.postgresql.base.DatabaseWrapper.ensure_connection",
+            side_effect=lambda: call_order.append("super_ensure"),
+        ),
+    ):
+        wrapper.ensure_connection()
+
+    assert call_order == ["super_ensure"]
+
+
+def test_ensure_connection_runs_health_check_before_super_when_connection_exists():
+    wrapper = make_wrapper()
+    wrapper.connection = "existing"  # any non-None value simulates a live connection
     call_order = []
 
     with (
@@ -27,24 +51,32 @@ def test_ensure_connection_calls_health_check_before_super():
     assert call_order == ["health_check", "super_ensure"]
 
 
-def test_ensure_connection_checks_health_even_with_existing_connection():
+def test_ensure_connection_does_not_recurse_like_django_get_autocommit():
+    """Regression: Django's close_if_unusable_or_obsolete calls get_autocommit,
+    which calls ensure_connection when no connection is open. The wrapper must
+    not recurse into itself in that scenario."""
     wrapper = make_wrapper()
-    wrapper.connection = "existing"  # any non-None value simulates a live connection
-    health_check_called = []
+    wrapper.connection = None
+    ensure_calls = []
+
+    def fake_close_if_unusable_or_obsolete():
+        # Mimic Django: get_autocommit() -> ensure_connection() when conn is None
+        wrapper.ensure_connection()
 
     with (
         patch.object(
             DatabaseWrapper,
             "close_if_unusable_or_obsolete",
-            side_effect=lambda: health_check_called.append(True),
+            side_effect=fake_close_if_unusable_or_obsolete,
         ),
         patch(
             "django.db.backends.postgresql.base.DatabaseWrapper.ensure_connection",
+            side_effect=lambda: ensure_calls.append(True),
         ),
     ):
-        wrapper.ensure_connection()
+        wrapper.ensure_connection()  # must not raise RecursionError
 
-    assert health_check_called
+    assert ensure_calls == [True]
 
 
 def test_worker_settings_uses_custom_backend_engine():


### PR DESCRIPTION
Check if the is a connection before running the clean_obsolete ones, otherwise this triggers a infinite recursion execption.

This PR: should fix https://embl.atlassian.net/browse/EMG-9665

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
