### PR TITLE
Add a flow to sync the metadata for the studies

### DIFF
--- a/workflows/flows/housekeeping/sync_studies_with_ena.py
+++ b/workflows/flows/housekeeping/sync_studies_with_ena.py
@@ -1,0 +1,81 @@
+from prefect import get_run_logger
+
+from activate_django_first import EMG_CONFIG  # noqa: F401
+
+import ena.models
+from workflows.ena_utils.ena_api_requests import sync_study_metadata_from_ena
+from workflows.prefect_utils.flows_utils import (
+    django_db_flow as flow,
+    django_db_task as task,
+)
+
+
+@task(name="Sync batch of studies metadata from ENA")
+def sync_studies(study_accessions: list[str]):
+    """Sync metadata for a batch of studies from ENA.
+
+    Each study is synced individually with try/except so that a failure
+    for one study does not block the rest of the batch.
+
+    :param study_accessions: List of study accessions to sync.
+    :return: List of accessions that failed to sync.
+    """
+    logger = get_run_logger()
+    failed = []
+    for study_accession in study_accessions:
+        try:
+            study = ena.models.Study.objects.get_ena_study(study_accession)
+            logger.info(f"Syncing metadata for study {study.accession}")
+            sync_study_metadata_from_ena(study)
+            logger.info(f"Successfully synced metadata for study {study.accession}")
+        except Exception as e:
+            logger.error(f"Failed to sync study {study_accession}: {e}")
+            failed.append(study_accession)
+    return failed
+
+
+@flow(flow_run_name="Sync studies with ENA")
+def sync_studies_with_ena(
+    accessions: list[str] | None = None,
+    all_studies: bool = False,
+    batch_size: int = 50,
+):
+    """Sync study metadata from ENA for a list of accessions or all studies.
+
+    Studies are processed in batches to avoid long-running DB connections.
+
+    :param accessions: List of study accessions to sync.
+    :param all_studies: If True, sync all studies.
+    :param batch_size: Number of studies to process per batch (default 50).
+    """
+    logger = get_run_logger()
+
+    if accessions and all_studies:
+        raise ValueError("Cannot provide both accessions and all_studies")
+
+    if not accessions and not all_studies:
+        raise ValueError("Must provide either accessions or all_studies=True")
+
+    if accessions:
+        study_accessions = accessions
+    else:
+        study_accessions = list(
+            ena.models.Study.objects.values_list("accession", flat=True)
+        )
+
+    total = len(study_accessions)
+    logger.info(f"Syncing metadata for {total} studies in batches of {batch_size}")
+
+    all_failed = []
+    for i in range(0, total, batch_size):
+        batch = study_accessions[i : i + batch_size]
+        logger.info(f"Processing batch {i // batch_size + 1} ({len(batch)} studies)")
+        failed = sync_studies(batch)
+        all_failed.extend(failed)
+
+    if all_failed:
+        logger.warning(
+            f"Failed to sync {len(all_failed)} studies: {', '.join(all_failed)}"
+        )
+    else:
+        logger.info("All studies synced successfully")

--- a/workflows/tests/test_sync_studies_with_ena.py
+++ b/workflows/tests/test_sync_studies_with_ena.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+import pytest
+
+from ena.models import Study
+from workflows.flows.housekeeping.sync_studies_with_ena import (
+    sync_studies_with_ena,
+)
+
+
+@patch(
+    "workflows.flows.housekeeping.sync_studies_with_ena.sync_study_metadata_from_ena"
+)
+@pytest.mark.django_db
+def test_sync_studies_with_ena_by_accessions(mock_sync, prefect_harness):
+    """Test that the flow syncs specific studies by accession, handling failures."""
+    prj_01, _ = Study.objects.get_or_create(accession="PRJNA000001", title="Study OK")
+    prj_02, _ = Study.objects.get_or_create(accession="PRJNA000002", title="Study Fail")
+
+    def mock_sync_study(study: Study):
+        if study.accession == "PRJNA000002":
+            raise RuntimeError("ENA error")
+        study.title = "Study OK - and updated!"
+        study.metadata["description"] = "Study OK - description updated!"
+        study.save()
+        return
+
+    mock_sync.side_effect = mock_sync_study
+
+    sync_studies_with_ena(
+        accessions=["PRJNA000001", "PRJNA000002"],
+        batch_size=10,
+    )
+
+    prj_01.refresh_from_db()
+    assert prj_01.title == "Study OK - and updated!"
+    assert prj_01.metadata["description"] == "Study OK - description updated!"
+
+    assert mock_sync.call_count == 2


### PR DESCRIPTION
This PR:
* Using the command sync_studies_with_ena - adds a flow to run this instead of a command


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
