### PR TITLE
Feature/run assemblies

### DIFF
--- a/analyses/schemas.py
+++ b/analyses/schemas.py
@@ -318,7 +318,9 @@ class ExperimentTypeMixin(Schema):
 
 
 class AnalysedRun(ModelSchema, ExperimentTypeMixin):
-    accession: str = Field(..., alias="first_accession", examples=["ERR0000001"])
+    accession: Optional[str] = Field(
+        None, alias="first_accession", examples=["ERR0000001"]
+    )
     sample_accession: Optional[str] = Field(
         None,
         description="ENA accession of the sample associated with this run",

--- a/emgapiv2/api/runs.py
+++ b/emgapiv2/api/runs.py
@@ -10,7 +10,7 @@ from ninja_extra.exceptions import NotFound
 from ninja import FilterSchema
 
 import analyses.models
-from analyses.schemas import AnalysedRun, AnalysedRunDetail, MGnifyAnalysis
+from analyses.schemas import AnalysedRun, AnalysedRunDetail, MGnifyAnalysis, Assembly
 from emgapiv2.api import ApiSections
 from emgapiv2.api import perms
 from emgapiv2.api.auth import WebinJWTAuth, DjangoSuperUserAuth, NoAuth
@@ -27,7 +27,7 @@ class RunListFilters(FilterSchema):
         description="If set, will only show runs with the specified experiment type",
     )
 
-    def filter_has_experiment_type(self, experiment_type: str | None) -> Q:
+    def filter_has_experiment_type(self, experiment_type: Optional[str]) -> Q:
         if not experiment_type:
             return Q()
         return Q(experiment_type=experiment_type)
@@ -109,6 +109,12 @@ class AnalysedRunController(UnauthorisedIsUnfoundController):
                     self_object_name="run",
                     description="Analyses performed on this run",
                 ),
+                **make_child_link(
+                    operation_id="list_runs_assemblies",
+                    child_name="assemblies",
+                    self_object_name="run",
+                    description="Assemblies generated from or including this run",
+                ),
             }
         ),
         auth=[WebinJWTAuth(), DjangoSuperUserAuth(), NoAuth()],
@@ -163,3 +169,39 @@ class AnalysedRunController(UnauthorisedIsUnfoundController):
         # raise not found if user doesn't have permission to see
         self.check_object_permissions(run)
         return run.analyses.filter(is_ready=True)
+
+    @http_get(
+        "/{accession}/assemblies/",
+        response=NinjaPaginationResponseSchema[Assembly],
+        summary="List Assemblies associated with this Run",
+        description="Assemblies generated from or including this run",
+        operation_id="list_runs_assemblies",
+        tags=[ApiSections.RUNS, ApiSections.ASSEMBLIES],
+        openapi_extra=make_links_section(
+            make_related_detail_link(
+                related_detail_operation_id="get_assembly",
+                self_object_name="run",
+                related_object_name="assembly",
+                related_id_in_response="accession",
+                from_list_to_detail=True,
+            )
+        ),
+        auth=[WebinJWTAuth(), DjangoSuperUserAuth(), NoAuth()],
+        permissions=[
+            perms.IsPublic | perms.IsWebinOwner | perms.IsAdminUserWithObjectPerms
+        ],
+    )
+    @paginate()
+    def list_runs_assemblies(self, accession: str):
+        try:
+            run = analyses.models.Run.objects.get_by_accession(accession)
+        except (
+            analyses.models.Run.DoesNotExist,
+            analyses.models.Run.MultipleObjectsReturned,
+        ):
+            raise NotFound(detail=f"Analysed run with accession {accession} not found.")
+        # raise not found if user doesn't have permission to see
+        self.check_object_permissions(run)
+        return run.assemblies.select_related(
+            "reads_study", "assembly_study", "assembler", "sample"
+        )

--- a/emgapiv2/test_api.py
+++ b/emgapiv2/test_api.py
@@ -617,3 +617,36 @@ def test_list_sample_runs(ninja_api_client, raw_reads_mgnify_sample, raw_read_ru
             r.sample.ena_sample.accession for r in raw_read_run
         ]
         assert run["study_accession"] in [r.study.accession for r in raw_read_run]
+
+
+@pytest.mark.django_db
+def test_runs_assemblies_list(ninja_api_client, raw_read_run, mgnify_assemblies_with_ena):
+    # The first run (SRR6180434) has two assemblies in the fixtures: one metaspades and one megahit
+    run = raw_read_run[0]
+
+    items = call_endpoint_and_get_data(
+        ninja_api_client,
+        f"/runs/{run.ena_accessions[0]}/assemblies/",
+        count=2,
+    )
+
+    # Ensure returned items belong to our fixture set and have expected fields
+    returned_accessions = [item["accession"] for item in items]
+    all_fixture_accessions = [a.first_accession for a in mgnify_assemblies_with_ena]
+
+    assert len(items) == 2
+    for acc in returned_accessions:
+        assert acc in all_fixture_accessions
+    assert "updated_at" in items[0]
+
+
+@pytest.mark.django_db
+def test_runs_assemblies_private(ninja_api_client, private_run):
+    private_accession = private_run.ena_accessions[0]
+    response = ninja_api_client.get(f"/runs/{private_accession}/assemblies/")
+    assert (
+        response.status_code == 404
+    ), "Private runs should not be visible in the assemblies list endpoint"
+    assert (
+        "not found" in response.json()["detail"].lower()
+    ), "Response should indicate not found"

--- a/emgapiv2/test_api.py
+++ b/emgapiv2/test_api.py
@@ -620,7 +620,9 @@ def test_list_sample_runs(ninja_api_client, raw_reads_mgnify_sample, raw_read_ru
 
 
 @pytest.mark.django_db
-def test_runs_assemblies_list(ninja_api_client, raw_read_run, mgnify_assemblies_with_ena):
+def test_runs_assemblies_list(
+    ninja_api_client, raw_read_run, mgnify_assemblies_with_ena
+):
     # The first run (SRR6180434) has two assemblies in the fixtures: one metaspades and one megahit
     run = raw_read_run[0]
 


### PR DESCRIPTION
This PR: exposes the runs/accession/assemblies endpoint, which returns the assemblies linked to runs via the pre-established many-to-many relationship.
*


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
