### PR TITLE
EMG-8989 Adjust "pipeline version undefined" in study summaries

### DIFF
--- a/analyses/management/commands/add_pipeline_to_study_downloads_download_groups.py
+++ b/analyses/management/commands/add_pipeline_to_study_downloads_download_groups.py
@@ -1,0 +1,92 @@
+from django.core.management.base import BaseCommand
+from analyses.models import Study
+from analyses.base_models.with_experiment_type_models import WithExperimentTypeModel
+
+
+class Command(BaseCommand):
+    help = "Update the download_group for all Study downloads to include the pipeline version and type."
+
+    def handle(self, *args, **options):
+        # Filter studies with non-empty downloads list. In Django JSONField, we can exclude []
+        studies = Study.objects.exclude(downloads=[])
+        count = 0
+        for study in studies:
+            analyses = study.analyses.all()
+            if not analyses.exists():
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Study {study.accession} has no analyses. Skipping."
+                    )
+                )
+                continue
+
+            # Infer the experiment type based on the analyses
+            experiment_types = set(analyses.values_list("experiment_type", flat=True))
+
+            inferred_type = None
+            if all(
+                et == WithExperimentTypeModel.ExperimentTypes.AMPLICON
+                for et in experiment_types
+            ):
+                inferred_type = "amplicon"
+            elif all(
+                et
+                in [
+                    WithExperimentTypeModel.ExperimentTypes.ASSEMBLY,
+                    WithExperimentTypeModel.ExperimentTypes.HYBRID_ASSEMBLY,
+                    WithExperimentTypeModel.ExperimentTypes.LONG_READ_ASSEMBLY,
+                ]
+                for et in experiment_types
+            ):
+                inferred_type = "assembly"
+            elif any(
+                et
+                in [
+                    WithExperimentTypeModel.ExperimentTypes.METAGENOMIC,
+                    WithExperimentTypeModel.ExperimentTypes.METATRANSCRIPTOMIC,
+                ]
+                for et in experiment_types
+            ):
+                inferred_type = "rawreads"
+
+            if not inferred_type:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Could not infer experiment type for study {study.accession} with types {experiment_types}. Skipping."
+                    )
+                )
+                continue
+
+            updated = False
+            version = "v6"
+
+            for download in study.downloads:
+                current_group = download.get("download_group", "")
+                if (
+                    current_group.startswith("study_summary")
+                    and f".{version}." not in current_group
+                ):
+                    # Replace "study_summary" with "study_summary.v6.<inferred_type>"
+                    # If current_group was "study_summary.suffix", it becomes "study_summary.v6.type.suffix"
+                    # If current_group was "study_summary", it becomes "study_summary.v6.type"
+                    if current_group == "study_summary":
+                        new_group = f"study_summary.{version}.{inferred_type}"
+                    else:
+                        new_group = current_group.replace(
+                            "study_summary.",
+                            f"study_summary.{version}.{inferred_type}.",
+                        )
+
+                    download["download_group"] = new_group
+                    updated = True
+
+            if updated:
+                study.save()
+                count += 1
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"Updated study {study.accession} with inferred type '{inferred_type}'."
+                    )
+                )
+
+        self.stdout.write(self.style.SUCCESS(f"Successfully updated {count} studies."))

--- a/analyses/tests/test_add_pipeline_to_study_downloads_download_groups.py
+++ b/analyses/tests/test_add_pipeline_to_study_downloads_download_groups.py
@@ -1,0 +1,209 @@
+import pytest
+from django.core.management import call_command
+from analyses.models import Study, Analysis
+from analyses.base_models.with_experiment_type_models import WithExperimentTypeModel
+from analyses.base_models.with_downloads_models import (
+    DownloadFile,
+    DownloadType,
+    DownloadFileType,
+)
+
+
+@pytest.mark.django_db
+def test_add_pipeline_to_study_downloads_download_groups(
+    raw_reads_mgnify_study, raw_reads_mgnify_sample, raw_read_run
+):
+    # Setup: 3 studies with different types of analyses
+    sample = raw_reads_mgnify_sample[0]
+    run = raw_read_run[0]
+
+    # 1. Amplicon Study
+    amplicon_study = Study.objects.create(
+        accession="MGYS00001001",
+        title="Amplicon Study",
+        ena_study=raw_reads_mgnify_study.ena_study,
+    )
+    Analysis.objects.create(
+        accession="MGYA00001001",
+        study=amplicon_study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.AMPLICON,
+    )
+    # Test with both "study_summary.suffix" and just "study_summary"
+    amplicon_study.add_download(
+        DownloadFile(
+            path="s1.tsv",
+            alias="a1",
+            download_type=DownloadType.TAXONOMIC_ANALYSIS,
+            file_type=DownloadFileType.TSV,
+            download_group="study_summary.silva-ssu",
+            short_description="short",
+            long_description="long",
+        )
+    )
+    amplicon_study.add_download(
+        DownloadFile(
+            path="s1_2.tsv",
+            alias="a1_2",
+            download_type=DownloadType.TAXONOMIC_ANALYSIS,
+            file_type=DownloadFileType.TSV,
+            download_group="study_summary",
+            short_description="short",
+            long_description="long",
+        )
+    )
+
+    # 2. Assembly Study
+    assembly_study = Study.objects.create(
+        accession="MGYS00001002",
+        title="Assembly Study",
+        ena_study=raw_reads_mgnify_study.ena_study,
+    )
+    Analysis.objects.create(
+        accession="MGYA00001002",
+        study=assembly_study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.ASSEMBLY,
+    )
+    assembly_study.add_download(
+        DownloadFile(
+            path="s2.tsv",
+            alias="a2",
+            download_type=DownloadType.TAXONOMIC_ANALYSIS,
+            file_type=DownloadFileType.TSV,
+            download_group="study_summary.ko",
+            short_description="short",
+            long_description="long",
+        )
+    )
+
+    # 3. Raw Reads Study (Metagenomic)
+    rawreads_study = Study.objects.create(
+        accession="MGYS00001003",
+        title="Raw Reads Study",
+        ena_study=raw_reads_mgnify_study.ena_study,
+    )
+    Analysis.objects.create(
+        accession="MGYA00001003",
+        study=rawreads_study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.METAGENOMIC,
+    )
+    rawreads_study.add_download(
+        DownloadFile(
+            path="s3.tsv",
+            alias="a3",
+            download_type=DownloadType.TAXONOMIC_ANALYSIS,
+            file_type=DownloadFileType.TSV,
+            download_group="study_summary.motus",
+            short_description="short",
+            long_description="long",
+        )
+    )
+
+    # 4. Study with mixed raw reads
+    mixed_study = Study.objects.create(
+        accession="MGYS00001004",
+        title="Mixed Study",
+        ena_study=raw_reads_mgnify_study.ena_study,
+    )
+    Analysis.objects.create(
+        accession="MGYA00001004",
+        study=mixed_study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.METAGENOMIC,
+    )
+    Analysis.objects.create(
+        accession="MGYA00001005",
+        study=mixed_study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.METATRANSCRIPTOMIC,
+    )
+    mixed_study.add_download(
+        DownloadFile(
+            path="s4.tsv",
+            alias="a4",
+            download_type=DownloadType.TAXONOMIC_ANALYSIS,
+            file_type=DownloadFileType.TSV,
+            download_group="study_summary.goslim",
+            short_description="short",
+            long_description="long",
+        )
+    )
+
+    # 5. Study with no analyses (should be skipped)
+    empty_study = Study.objects.create(
+        accession="MGYS00001005",
+        title="Empty Study",
+        ena_study=raw_reads_mgnify_study.ena_study,
+    )
+    empty_study.add_download(
+        DownloadFile(
+            path="s5.tsv",
+            alias="a5",
+            download_type=DownloadType.TAXONOMIC_ANALYSIS,
+            file_type=DownloadFileType.TSV,
+            download_group="study_summary.something",
+            short_description="short",
+            long_description="long",
+        )
+    )
+
+    # 6. Study with no downloads (should be excluded from queryset)
+    nodl_study = Study.objects.create(
+        accession="MGYS00001006",
+        title="No Downloads Study",
+        ena_study=raw_reads_mgnify_study.ena_study,
+    )
+    # Give it an analysis so it WOULD be processed if it had downloads
+    Analysis.objects.create(
+        accession="MGYA00001006",
+        study=nodl_study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.AMPLICON,
+    )
+
+    # Run the command
+    call_command("add_pipeline_to_study_downloads_download_groups")
+
+    # Refresh from DB and verify
+    amplicon_study.refresh_from_db()
+    assert (
+        amplicon_study.downloads[0]["download_group"]
+        == "study_summary.v6.amplicon.silva-ssu"
+    )
+    assert amplicon_study.downloads[1]["download_group"] == "study_summary.v6.amplicon"
+
+    assembly_study.refresh_from_db()
+    assert (
+        assembly_study.downloads[0]["download_group"] == "study_summary.v6.assembly.ko"
+    )
+
+    rawreads_study.refresh_from_db()
+    assert (
+        rawreads_study.downloads[0]["download_group"]
+        == "study_summary.v6.rawreads.motus"
+    )
+
+    mixed_study.refresh_from_db()
+    assert (
+        mixed_study.downloads[0]["download_group"] == "study_summary.v6.rawreads.goslim"
+    )
+
+    empty_study.refresh_from_db()
+    assert empty_study.downloads[0]["download_group"] == "study_summary.something"
+
+    nodl_study.refresh_from_db()
+    assert nodl_study.downloads == []

--- a/workflows/data_io_utils/schemas/assembly.py
+++ b/workflows/data_io_utils/schemas/assembly.py
@@ -39,6 +39,8 @@ from .base import (
     ImportConfig,
 )
 
+# TODO: move this to pipeline-versioned directory (very v6 specific)
+
 
 class ImportResult(BaseModel):
     """

--- a/workflows/flows/analyse_study_tasks/shared/dwcr_generator.py
+++ b/workflows/flows/analyse_study_tasks/shared/dwcr_generator.py
@@ -221,7 +221,7 @@ def add_dwcr_summaries_to_downloads(mgnify_study_accession: str):
                 DownloadFile(
                     path=Path("study-summaries") / summary_file.name,
                     download_type=DownloadType.TAXONOMIC_ANALYSIS,
-                    download_group="study_summary",
+                    download_group=f"study_summary.{pipeline_config.pipeline_version}.{pipeline_config.pipeline_name}",
                     file_type=DownloadFileType.CSV,
                     short_description=f"DwC-Ready summary of {region} ASV taxonomies using {db} as ref DB",
                     long_description=f"DwC-Ready summary of {region} ASV taxonomies using {db} as ref DB, across all runs in the study",

--- a/workflows/flows/analyse_study_tasks/shared/study_summary.py
+++ b/workflows/flows/analyse_study_tasks/shared/study_summary.py
@@ -244,7 +244,9 @@ def add_study_summaries_to_downloads(
 
     :param mgnify_study_accession: The accession identifier for the study to process.
     """
-    pipeline_config = PIPELINE_CONFIGS[analysis_type]
+    pipeline_config = PIPELINE_CONFIGS[
+        analysis_type
+    ]  # TODO: this will not scale to future pipeline versions
 
     logger = get_run_logger()
     study = Study.objects.get(accession=mgnify_study_accession)
@@ -276,7 +278,7 @@ def add_study_summaries_to_downloads(
                 DownloadFile(
                     path=Path("study-summaries") / summary_file.name,
                     download_type=DownloadType.TAXONOMIC_ANALYSIS,
-                    download_group="study_summary",
+                    download_group=f"study_summary.{pipeline_config.pipeline_version}.{pipeline_config.pipeline_name}",
                     file_type=DownloadFileType.TSV,
                     short_description=f"Summary of {db_or_region} taxonomies",
                     long_description=f"Summary of {db_or_region} taxonomic assignments, across all runs in the study",

--- a/workflows/flows/analysis/assembly/tasks/add_assembly_study_summaries_to_downloads.py
+++ b/workflows/flows/analysis/assembly/tasks/add_assembly_study_summaries_to_downloads.py
@@ -95,7 +95,7 @@ def add_assembly_study_summaries_to_downloads(
                 if is_taxonomy
                 else DownloadType.FUNCTIONAL_ANALYSIS
             ),
-            download_group=f"study_summary.{matched_type.source}",
+            download_group=f"study_summary.v6.assembly.{matched_type.source}",  # hard-coded pipeline in this case
             file_type=DownloadFileType.TSV,
             short_description=matched_type.short_description,
             long_description=matched_type.long_description,

--- a/workflows/tests/test_add_assembly_study_summaries_to_downloads.py
+++ b/workflows/tests/test_add_assembly_study_summaries_to_downloads.py
@@ -40,7 +40,7 @@ class TestAddAssemblyStudySummariesToDownloads:
         taxonomy_download = next(
             d
             for d in study.downloads_as_objects
-            if d.download_group == "study_summary.taxonomy"
+            if d.download_group == "study_summary.v6.assembly.taxonomy"
         )
         assert taxonomy_download.download_type == DownloadType.TAXONOMIC_ANALYSIS
 
@@ -48,7 +48,7 @@ class TestAddAssemblyStudySummariesToDownloads:
         ko_download = next(
             d
             for d in study.downloads_as_objects
-            if d.download_group == "study_summary.ko"
+            if d.download_group == "study_summary.v6.assembly.ko"
         )
         assert ko_download.download_type == DownloadType.FUNCTIONAL_ANALYSIS
 

--- a/workflows/tests/test_analysis_assembly_study_flow.py
+++ b/workflows/tests/test_analysis_assembly_study_flow.py
@@ -760,7 +760,7 @@ def test_prefect_analyse_assembly_flow(
     taxonomy_downloads = [
         d
         for d in study.downloads_as_objects
-        if d.download_group == "study_summary.taxonomy"
+        if d.download_group == "study_summary.v6.assembly.taxonomy"
     ]
     assert len(taxonomy_downloads) == 1
     assert taxonomy_downloads[0].download_type == DownloadType.TAXONOMIC_ANALYSIS
@@ -780,7 +780,7 @@ def test_prefect_analyse_assembly_flow(
         functional_downloads = [
             d
             for d in study.downloads_as_objects
-            if d.download_group == f"study_summary.{source}"
+            if d.download_group == f"study_summary.v6.assembly.{source}"
         ]
         assert len(functional_downloads) == 1, f"Missing {source} summary"
         assert functional_downloads[0].download_type == DownloadType.FUNCTIONAL_ANALYSIS
@@ -794,7 +794,7 @@ def test_prefect_analyse_assembly_flow(
     study_summary_downloads = [
         d
         for d in study.downloads_as_objects
-        if d.download_group.startswith("study_summary")
+        if d.download_group.startswith("study_summary.v6.assembly")
     ]
     assert len(study_summary_downloads) == 8
 


### PR DESCRIPTION
This PR:
* adds the pipeline version to the `download_group` of V6 study summaries. It was there in fixtures, but not set when the studies were added.
* this is done in two ways because ASA does them differently to AMP and RAWR
* adds a management command to migrate existing downloads to the new format

This fixes EMG-8989:
* the `.v6.` part of the `download_group` is used by the website to group a study's summaries into their pipeline versions


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
