### PR TITLE
Used AssemblyDetail object for /run/assemblies response

### DIFF
--- a/emgapiv2/api/runs.py
+++ b/emgapiv2/api/runs.py
@@ -10,7 +10,12 @@ from ninja_extra.exceptions import NotFound
 from ninja import FilterSchema
 
 import analyses.models
-from analyses.schemas import AnalysedRun, AnalysedRunDetail, MGnifyAnalysis, Assembly
+from analyses.schemas import (
+    AnalysedRun,
+    AnalysedRunDetail,
+    MGnifyAnalysis,
+    AssemblyDetail,
+)
 from emgapiv2.api import ApiSections
 from emgapiv2.api import perms
 from emgapiv2.api.auth import WebinJWTAuth, DjangoSuperUserAuth, NoAuth
@@ -172,7 +177,7 @@ class AnalysedRunController(UnauthorisedIsUnfoundController):
 
     @http_get(
         "/{accession}/assemblies/",
-        response=NinjaPaginationResponseSchema[Assembly],
+        response=NinjaPaginationResponseSchema[AssemblyDetail],
         summary="List Assemblies associated with this Run",
         description="Assemblies generated from or including this run",
         operation_id="list_runs_assemblies",
@@ -202,6 +207,11 @@ class AnalysedRunController(UnauthorisedIsUnfoundController):
             raise NotFound(detail=f"Analysed run with accession {accession} not found.")
         # raise not found if user doesn't have permission to see
         self.check_object_permissions(run)
-        return run.assemblies.select_related(
-            "reads_study", "assembly_study", "assembler", "sample"
+        return (
+            analyses.models.Assembly.public_objects.select_related(
+                "reads_study", "assembly_study", "assembler", "sample"
+            )
+            .prefetch_related("runs")
+            .filter(runs__ena_accessions__contains=[accession])
+            .distinct()
         )

--- a/emgapiv2/test_api.py
+++ b/emgapiv2/test_api.py
@@ -639,7 +639,29 @@ def test_runs_assemblies_list(
     assert len(items) == 2
     for acc in returned_accessions:
         assert acc in all_fixture_accessions
-    assert "updated_at" in items[0]
+
+    # Validate presence and content of extra fields
+    for item in items:
+        assert (
+            item.get("run_accession")
+            in [r.first_accession for r in run.assemblies.first().runs.all()]
+            or item.get("run_accession") is not None
+        )
+        assert item.get("sample_accession") == run.sample.ena_sample.accession
+        assert item.get("reads_study_accession") == run.study.accession
+        # assembly_study_accession may be None in fixtures
+        assert "assembly_study_accession" in item
+        assert item.get("assembler_name") in [
+            a.assembler.name
+            for a in mgnify_assemblies_with_ena
+            if a.first_accession in returned_accessions
+        ]
+        assert item.get("assembler_version") in [
+            a.assembler.version
+            for a in mgnify_assemblies_with_ena
+            if a.first_accession in returned_accessions
+        ]
+        assert "updated_at" in item
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
…tra fields|

This PR:
Adds AssemblyDetail object for /run/assemblies response to expose extra fields
*


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
