### PR TITLE
Clear stale db connections in the orchestrated jobs logic

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -213,6 +213,9 @@ fileignoreconfig:
 - filename: workflows/flows/housekeeping/clean_nextflow_workdirs.py
   allowed_patterns: [key]
 
+- filename: workflows/tests/test_flows_utils.py
+  checksum: 7044790c62db033597a0c9391751a32f2db1f88d5ba5a953b6c607d97ff7ed6d
+
 allowed_patterns:
 - cache_key_fn
 - CommonMetadataKeys

--- a/workflows/prefect_utils/flows_utils.py
+++ b/workflows/prefect_utils/flows_utils.py
@@ -1,11 +1,11 @@
 import functools
-from typing import Callable
+from typing import Callable, Optional
 
 import prefect
 from django.db import connections
 
 
-def _close_stale_connections() -> None:
+def close_stale_connections() -> None:
     """
     Close Django DB connections that are unusable or past their max age,
     skipping any connection that is currently inside an atomic block.
@@ -23,7 +23,7 @@ def _close_stale_connections() -> None:
             conn.close_if_unusable_or_obsolete()
 
 
-def django_db_flow(**flow_kwargs) -> Callable:
+def django_db_flow(_fn: Optional[Callable] = None, **flow_kwargs) -> Callable:
     """
     Drop-in replacement for prefect ``@flow`` that automatically closes stale Django DB
     connections before the flow body runs.
@@ -44,15 +44,18 @@ def django_db_flow(**flow_kwargs) -> Callable:
     def decorator(fn: Callable) -> Callable:
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
-            _close_stale_connections()
+            close_stale_connections()
             return fn(*args, **kwargs)
 
         return prefect_decorator(wrapper)
 
+    if _fn is not None:
+        return decorator(_fn)
+
     return decorator
 
 
-def django_db_task(**task_kwargs) -> Callable:
+def django_db_task(_fn: Optional[Callable] = None, **task_kwargs) -> Callable:
     """
     Drop-in replacement for prefect ``@task`` that automatically closes stale Django DB
     connections before the task body runs.
@@ -73,9 +76,12 @@ def django_db_task(**task_kwargs) -> Callable:
     def decorator(fn: Callable) -> Callable:
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
-            _close_stale_connections()
+            close_stale_connections()
             return fn(*args, **kwargs)
 
         return prefect_decorator(wrapper)
+
+    if _fn is not None:
+        return decorator(_fn)
 
     return decorator

--- a/workflows/prefect_utils/flows_utils.py
+++ b/workflows/prefect_utils/flows_utils.py
@@ -1,8 +1,23 @@
 import functools
-from typing import Callable, Optional
+import inspect
+from functools import partial
+from typing import (
+    Any,
+    Callable,
+    Coroutine,
+    Optional,
+    ParamSpec,
+    TypeVar,
+    cast,
+    overload,
+)
 
-import prefect
 from django.db import connections
+from prefect.flows import Flow
+from prefect.tasks import Task
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def close_stale_connections() -> None:
@@ -23,65 +38,123 @@ def close_stale_connections() -> None:
             conn.close_if_unusable_or_obsolete()
 
 
-def django_db_flow(_fn: Optional[Callable] = None, **flow_kwargs) -> Callable:
+@overload
+def _refresh_connections_before_call(
+    fn: Callable[P, R],
+) -> Callable[P, R]: ...
+
+
+@overload
+def _refresh_connections_before_call(
+    fn: Callable[P, Coroutine[Any, Any, R]],
+) -> Callable[P, Coroutine[Any, Any, R]]: ...
+
+
+def _refresh_connections_before_call(fn: Callable[P, Any]) -> Callable[P, Any]:
+    if inspect.iscoroutinefunction(fn):
+        async_fn = cast(Callable[P, Coroutine[Any, Any, Any]], fn)
+
+        # This repository does not currently define async tasks or flows, so this
+        # branch hasn't been tested with real workflows. The unit tests cover it, and
+        # we expect it to behave correctly if async workflows are introduced later.
+        @functools.wraps(fn)
+        async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+            close_stale_connections()
+            return await async_fn(*args, **kwargs)
+
+        return async_wrapper
+
+    sync_fn = cast(Callable[P, Any], fn)
+
+    @functools.wraps(fn)
+    def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+        close_stale_connections()
+        return sync_fn(*args, **kwargs)
+
+    return sync_wrapper
+
+
+@overload
+def django_db_flow(_fn: Callable[P, R]) -> Flow[P, R]: ...
+
+
+@overload
+def django_db_flow(
+    _fn: Callable[P, Coroutine[Any, Any, R]],
+) -> Flow[P, Coroutine[Any, Any, R]]: ...
+
+
+@overload
+def django_db_flow(
+    _fn: None = None, **flow_kwargs: Any
+) -> Callable[[Callable[P, R]], Flow[P, R]]: ...
+
+
+def django_db_flow(
+    _fn: Optional[Callable[P, Any]] = None, **flow_kwargs: Any
+) -> Flow[P, Any] | Callable[[Callable[P, Any]], Flow[P, Any]]:
     """
     Drop-in replacement for prefect ``@flow`` that automatically closes stale Django DB
     connections before the flow body runs.
 
     Usage is identical to ``@flow`` — just change the import::
 
-        from workflows.prefect_utils.flows_utils import django_flow
+        from workflows.prefect_utils.flows_utils import django_db_flow
 
-        @django_flow(name="my flow", log_prints=True)
+        @django_db_flow(name="my flow", log_prints=True)
         def my_flow():
             ...
 
     :param flow_kwargs: Keyword arguments forwarded verbatim to ``prefect.flow``.
     :return: Decorator that produces a Prefect Flow with connection refresh.
     """
-    prefect_decorator = prefect.flow(**flow_kwargs)
-
-    def decorator(fn: Callable) -> Callable:
-        @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
-            close_stale_connections()
-            return fn(*args, **kwargs)
-
-        return prefect_decorator(wrapper)
-
     if _fn is not None:
-        return decorator(_fn)
+        return Flow(fn=_refresh_connections_before_call(_fn), **flow_kwargs)
 
-    return decorator
+    return cast(
+        Callable[[Callable[P, Any]], Flow[P, Any]],
+        partial(django_db_flow, **flow_kwargs),
+    )
 
 
-def django_db_task(_fn: Optional[Callable] = None, **task_kwargs) -> Callable:
+@overload
+def django_db_task(_fn: Callable[P, R]) -> Task[P, R]: ...
+
+
+@overload
+def django_db_task(
+    _fn: Callable[P, Coroutine[Any, Any, R]],
+) -> Task[P, Coroutine[Any, Any, R]]: ...
+
+
+@overload
+def django_db_task(
+    _fn: None = None, **task_kwargs: Any
+) -> Callable[[Callable[P, R]], Task[P, R]]: ...
+
+
+def django_db_task(
+    _fn: Optional[Callable[P, Any]] = None, **task_kwargs: Any
+) -> Task[P, Any] | Callable[[Callable[P, Any]], Task[P, Any]]:
     """
     Drop-in replacement for prefect ``@task`` that automatically closes stale Django DB
     connections before the task body runs.
 
     Usage is identical to ``@task`` — just change the import::
 
-        from workflows.prefect_utils.flows_utils import django_task
+        from workflows.prefect_utils.flows_utils import django_db_task
 
-        @django_task(name="my task", retries=2)
+        @django_db_task(name="my task", retries=2)
         def my_task():
             ...
 
     :param task_kwargs: Keyword arguments forwarded verbatim to ``prefect.task``.
     :return: Decorator that produces a Prefect Task with connection refresh.
     """
-    prefect_decorator = prefect.task(**task_kwargs)
-
-    def decorator(fn: Callable) -> Callable:
-        @functools.wraps(fn)
-        def wrapper(*args, **kwargs):
-            close_stale_connections()
-            return fn(*args, **kwargs)
-
-        return prefect_decorator(wrapper)
-
     if _fn is not None:
-        return decorator(_fn)
+        return Task(fn=_refresh_connections_before_call(_fn), **task_kwargs)
 
-    return decorator
+    return cast(
+        Callable[[Callable[P, Any]], Task[P, Any]],
+        partial(django_db_task, **task_kwargs),
+    )

--- a/workflows/prefect_utils/slurm_flow.py
+++ b/workflows/prefect_utils/slurm_flow.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Union
 from django.conf import settings
 from django.urls import reverse
 from django.utils.timezone import now
-from prefect import flow, get_run_logger, task
+from prefect import get_run_logger
 from prefect.artifacts import create_markdown_artifact
 from prefect.runtime import flow_run
 from prefect_slurm.worker import SlurmWorker
@@ -20,6 +20,11 @@ from emgapiv2.log_utils import mask_sensitive_data as safe
 from workflows.models import OrchestratedClusterJob
 from workflows.nextflow_utils.tower import get_nextflow_tower_url
 from workflows.nextflow_utils.trace import maybe_get_nextflow_trace_df
+from workflows.prefect_utils.flows_utils import (
+    close_stale_connections,
+    django_db_flow as flow,
+    django_db_task as task,
+)
 from workflows.prefect_utils.prefect_worker_utils import (
     get_prefect_worker_type,
     make_environment,
@@ -73,6 +78,8 @@ def check_cluster_job(
     :param orchestrated_cluster_job: Orchestrated Cluster Job referencing the Slurm job
     :return: state of the job, as one of the string values of SlurmStatus.
     """
+    # Refresh Django connections before DB updates after the poll interval.
+    close_stale_connections()
     logger = get_run_logger()
     logger.info(f"Checking job {orchestrated_cluster_job}")
 
@@ -280,6 +287,9 @@ def start_or_attach_cluster_job(
     nf_link = get_nextflow_tower_url()
     nf_link_markdown = f"[Watch Nextflow Workflow]({nf_link})" if nf_link else ""
 
+    # Refresh Django connections before DB writes after any preparation job.
+    close_stale_connections()
+
     ocj = OrchestratedClusterJob.objects.create(
         cluster_job_id=job_id,
         flow_run_id=flow_run.id,
@@ -473,11 +483,15 @@ def run_subprocess(
         process.kill()
         process.wait()
 
+        # Refresh Django connections before saving after the subprocess wait.
+        close_stale_connections()
         ocj.last_known_state = SlurmStatus.failed
         ocj.save()
 
         raise SubprocessFailedException(process.pid, process.returncode, "Timed out")
 
+    # Refresh Django connections before saving after the subprocess wait.
+    close_stale_connections()
     if process.returncode == 0:
         logger.info(f"Job {ocj} finished successfully.")
 
@@ -670,7 +684,7 @@ def run_cluster_job(
 
     # Wait for job completion
     # Resumability: if this flow was re-run / restarted for some reason, or the exact same cluster job was sent later,
-    #  we should have gotten  back an existing slurm job_id of a previous run of it. And therefore the first status
+    #  we should have gotten back an existing slurm job_id of a previous run of it. And therefore the first status
     #  check will just tell us the job finished immediately / it'll wait for the EXISTING job to finish.
     is_job_in_terminal_state = False
     while not is_job_in_terminal_state:

--- a/workflows/prefect_utils/slurm_flow.py
+++ b/workflows/prefect_utils/slurm_flow.py
@@ -437,6 +437,8 @@ def run_subprocess(
             environment={},
         )
 
+    # Refresh Django connections before the first DB write after any preparation job.
+    close_stale_connections()
     env = make_environment(kwargs.get("environment", None))
 
     # need to submit new job
@@ -478,7 +480,7 @@ def run_subprocess(
 
     try:
         _stdout, stderr = process.communicate(timeout=expected_time.total_seconds())
-    except TimeoutError as e:
+    except (TimeoutError, subprocess.TimeoutExpired) as e:
         logger.error(f"Failed to run subprocess: {e}")
         process.kill()
         process.wait()

--- a/workflows/tests/test_cluster_jobs_integration.py
+++ b/workflows/tests/test_cluster_jobs_integration.py
@@ -1,10 +1,13 @@
 import logging
 import re
+import time
 import uuid
 from datetime import timedelta
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
+from django.db import connection
 from prefect import flow, task, runtime
 from prefect.runtime import flow_run
 
@@ -12,16 +15,19 @@ from workflows.models import OrchestratedClusterJob
 from workflows.prefect_utils.slurm_flow import (
     compute_hash_of_input_file,
     run_cluster_job,
+    run_subprocess,
+    start_or_attach_cluster_job,
 )
 from workflows.prefect_utils.slurm_policies import (
     DontResubmitIfOnlyInputFilesChangePolicy,
     ResubmitAlwaysPolicy,
     ResubmitIfFailedPolicy,
+    _SlurmResubmitPolicy,
 )
 from workflows.prefect_utils.slurm_status import SlurmStatus
 from workflows.prefect_utils.testing_utils import (
-    run_flow_and_capture_logs,
     combine_caplog_records,
+    run_flow_and_capture_logs,
 )
 
 
@@ -314,3 +320,96 @@ def test_passing_retries_to_task_subflow(prefect_harness):
     assert str(excinfo.value) == "Failing first time"
 
     assert task_that_includes_a_retriable_subflow(subflow_max_retries=2) == "Did yellow"
+
+
+@patch("workflows.prefect_utils.slurm_flow.store_nextflow_trace")
+@patch(
+    "workflows.prefect_utils.slurm_flow.flow_run",
+    new=type("FlowRun", (), {"id": uuid.uuid4()})(),
+)
+@patch("workflows.prefect_utils.slurm_flow.get_run_logger", return_value=MagicMock())
+@patch("workflows.prefect_utils.slurm_flow.create_markdown_artifact")
+@pytest.mark.django_db(transaction=True)
+def test_run_subprocess_recovers_stale_connection(
+    mock_create_markdown_artifact,
+    mock_get_run_logger,
+    mock_store_nextflow_trace,
+    tmp_path,
+):
+    with connection.cursor() as cursor:
+        cursor.execute("SET SESSION idle_session_timeout = '200ms'")
+
+    result = run_subprocess.fn(
+        name="subprocess stale connection test",
+        command="sleep 0.5",
+        expected_time=timedelta(seconds=2),
+        memory="100M",
+        environment={},
+        slurm_resubmit_policy=ResubmitAlwaysPolicy,
+        workdir=tmp_path / "work",
+    )
+
+    assert result.last_known_state == SlurmStatus.completed
+    connection.close()
+
+
+@patch(
+    "workflows.prefect_utils.slurm_flow.run_cluster_job",
+    side_effect=lambda *args, **kwargs: time.sleep(0.5),
+)
+@patch("workflows.prefect_utils.slurm_flow.submit_cluster_job", return_value=2)
+@patch(
+    "workflows.prefect_utils.slurm_flow.flow_run",
+    new=type("FlowRun", (), {"id": uuid.uuid4()})(),
+)
+@patch("workflows.prefect_utils.slurm_flow.get_run_logger", return_value=MagicMock())
+@patch("workflows.prefect_utils.slurm_flow.create_markdown_artifact")
+@pytest.mark.django_db(transaction=True)
+def test_start_or_attach_cluster_job_recovers_stale_connection_after_preparation(
+    mock_create_markdown_artifact,
+    mock_get_run_logger,
+    mock_submit_cluster_job,
+    mock_run_cluster_job,
+    tmp_path,
+):
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    prior_job_description = OrchestratedClusterJob.SlurmJobSubmitDescription(
+        name="slurm stale connection test",
+        time_limit="00-00:01:00",
+        memory_per_node="100M",
+        script="#!/bin/bash\nset -euo pipefail\necho 'test'\n",
+        working_directory=str(workdir),
+        environment="ALL",
+    )
+    OrchestratedClusterJob.objects.create(
+        cluster_job_id=1,
+        flow_run_id=uuid.uuid4(),
+        job_submit_description=prior_job_description,
+        input_files_hashes=[],
+        last_known_state=SlurmStatus.failed,
+    )
+    resubmit_policy = _SlurmResubmitPolicy(
+        policy_name="Resubmit with preparation command",
+        if_status_matches=[SlurmStatus.failed],
+        then_resubmit=True,
+        resubmit_needs_preparation_command="sleep 0.5",
+    )
+
+    with connection.cursor() as cursor:
+        cursor.execute("SET SESSION idle_session_timeout = '200ms'")
+
+    result = start_or_attach_cluster_job.fn(
+        name="slurm stale connection test",
+        command="echo 'test'",
+        expected_time=timedelta(minutes=1),
+        memory="100M",
+        slurm_resubmit_policy=resubmit_policy,
+        workdir=workdir,
+        make_workdir_first=True,
+        environment={},
+    )
+
+    assert result.id is not None
+    assert result.cluster_job_id != 1
+    connection.close()

--- a/workflows/tests/test_cluster_jobs_integration.py
+++ b/workflows/tests/test_cluster_jobs_integration.py
@@ -13,6 +13,8 @@ from prefect.runtime import flow_run
 
 from workflows.models import OrchestratedClusterJob
 from workflows.prefect_utils.slurm_flow import (
+    SubprocessFailedException,
+    check_cluster_job,
     compute_hash_of_input_file,
     run_cluster_job,
     run_subprocess,
@@ -29,6 +31,15 @@ from workflows.prefect_utils.testing_utils import (
     combine_caplog_records,
     run_flow_and_capture_logs,
 )
+
+
+@pytest.fixture
+def mock_slurm_flow_run():
+    with patch(
+        "workflows.prefect_utils.slurm_flow.flow_run",
+        new=type("FlowRun", (), {"id": uuid.uuid4()})(),
+    ):
+        yield
 
 
 @flow(log_prints=True, retries=2)
@@ -323,10 +334,6 @@ def test_passing_retries_to_task_subflow(prefect_harness):
 
 
 @patch("workflows.prefect_utils.slurm_flow.store_nextflow_trace")
-@patch(
-    "workflows.prefect_utils.slurm_flow.flow_run",
-    new=type("FlowRun", (), {"id": uuid.uuid4()})(),
-)
 @patch("workflows.prefect_utils.slurm_flow.get_run_logger", return_value=MagicMock())
 @patch("workflows.prefect_utils.slurm_flow.create_markdown_artifact")
 @pytest.mark.django_db(transaction=True)
@@ -334,6 +341,7 @@ def test_run_subprocess_recovers_stale_connection(
     mock_create_markdown_artifact,
     mock_get_run_logger,
     mock_store_nextflow_trace,
+    mock_slurm_flow_run,
     tmp_path,
 ):
     with connection.cursor() as cursor:
@@ -353,15 +361,119 @@ def test_run_subprocess_recovers_stale_connection(
     connection.close()
 
 
+@patch("workflows.prefect_utils.slurm_flow.store_nextflow_trace")
+@patch(
+    "workflows.prefect_utils.slurm_flow.run_cluster_job",
+    side_effect=lambda *args, **kwargs: time.sleep(0.5),
+)
+@patch(
+    "workflows.models.OrchestratedClusterJob.objects.get_previous_job",
+)
+@patch("workflows.prefect_utils.slurm_flow.get_run_logger", return_value=MagicMock())
+@patch("workflows.prefect_utils.slurm_flow.create_markdown_artifact")
+@pytest.mark.django_db(transaction=True)
+def test_run_subprocess_recovers_stale_connection_after_preparation_job(
+    mock_create_markdown_artifact,
+    mock_get_run_logger,
+    mock_get_previous_job,
+    mock_run_cluster_job,
+    mock_store_nextflow_trace,
+    mock_slurm_flow_run,
+    tmp_path,
+):
+    prior_job = MagicMock()
+    prior_job.should_resubmit_according_to_policy.return_value = True
+    mock_get_previous_job.return_value = prior_job
+    resubmit_policy = _SlurmResubmitPolicy(
+        policy_name="Resubmit subprocess with preparation command",
+        if_status_matches=[SlurmStatus.failed],
+        then_resubmit=True,
+        resubmit_needs_preparation_command="sleep 0.5",
+    )
+
+    with connection.cursor() as cursor:
+        cursor.execute("SET SESSION idle_session_timeout = '200ms'")
+
+    result = run_subprocess.fn(
+        name="subprocess stale connection with preparation test",
+        command="echo 'test'",
+        expected_time=timedelta(seconds=2),
+        memory="100M",
+        environment={},
+        slurm_resubmit_policy=resubmit_policy,
+        workdir=tmp_path / "work",
+    )
+
+    assert result.last_known_state == SlurmStatus.completed
+    mock_run_cluster_job.assert_called_once()
+    connection.close()
+
+
+@patch("workflows.prefect_utils.slurm_flow.store_nextflow_trace")
+@patch("workflows.prefect_utils.slurm_flow.get_run_logger", return_value=MagicMock())
+@patch("workflows.prefect_utils.slurm_flow.create_markdown_artifact")
+@pytest.mark.django_db(transaction=True)
+def test_run_subprocess_timeout_recovers_stale_connection(
+    mock_create_markdown_artifact,
+    mock_get_run_logger,
+    mock_store_nextflow_trace,
+    mock_slurm_flow_run,
+    tmp_path,
+):
+    with connection.cursor() as cursor:
+        cursor.execute("SET SESSION idle_session_timeout = '200ms'")
+
+    with pytest.raises(SubprocessFailedException, match="Timed out"):
+        run_subprocess.fn(
+            name="subprocess stale connection timeout test",
+            command="sleep 0.5",
+            expected_time=timedelta(seconds=0.3),
+            memory="100M",
+            environment={},
+            slurm_resubmit_policy=ResubmitAlwaysPolicy,
+            workdir=tmp_path / "work",
+        )
+
+    connection.close()
+
+
+@patch("workflows.prefect_utils.slurm_flow.pyslurm.db.Job")
+@patch("workflows.prefect_utils.slurm_flow.close_stale_connections")
+@patch("workflows.prefect_utils.slurm_flow.get_run_logger", return_value=MagicMock())
+@pytest.mark.django_db
+def test_check_cluster_job_refreshes_stale_connection_before_poll(
+    mock_get_run_logger, mock_close_stale_connections, mock_slurm_job, tmp_path
+):
+    orchestrated_job = OrchestratedClusterJob.objects.create(
+        cluster_job_id=123,
+        flow_run_id=uuid.uuid4(),
+        job_submit_description=OrchestratedClusterJob.SlurmJobSubmitDescription(
+            name="check stale connection test",
+            time_limit="00-00:01:00",
+            memory_per_node="100M",
+            script="echo test",
+            working_directory=str(tmp_path),
+            environment="ALL",
+        ),
+        input_files_hashes=[],
+    )
+
+    fake_slurm_job = MagicMock(
+        state=SlurmStatus.completed.value,
+        working_directory=str(tmp_path),
+    )
+    mock_slurm_job.return_value.load.return_value = fake_slurm_job
+    status = check_cluster_job(orchestrated_job)
+
+    assert status == SlurmStatus.completed.value
+    mock_close_stale_connections.assert_called_once_with()
+
+
 @patch(
     "workflows.prefect_utils.slurm_flow.run_cluster_job",
     side_effect=lambda *args, **kwargs: time.sleep(0.5),
 )
 @patch("workflows.prefect_utils.slurm_flow.submit_cluster_job", return_value=2)
-@patch(
-    "workflows.prefect_utils.slurm_flow.flow_run",
-    new=type("FlowRun", (), {"id": uuid.uuid4()})(),
-)
 @patch("workflows.prefect_utils.slurm_flow.get_run_logger", return_value=MagicMock())
 @patch("workflows.prefect_utils.slurm_flow.create_markdown_artifact")
 @pytest.mark.django_db(transaction=True)
@@ -370,6 +482,7 @@ def test_start_or_attach_cluster_job_recovers_stale_connection_after_preparation
     mock_get_run_logger,
     mock_submit_cluster_job,
     mock_run_cluster_job,
+    mock_slurm_flow_run,
     tmp_path,
 ):
     workdir = tmp_path / "work"

--- a/workflows/tests/test_flows_utils.py
+++ b/workflows/tests/test_flows_utils.py
@@ -1,11 +1,18 @@
 import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.db import connection, OperationalError
 from prefect import task
+from prefect.flows import Flow
+from prefect.tasks import Task
 
 from ena.models import Study
-from workflows.prefect_utils.flows_utils import django_db_task
+from workflows.prefect_utils.flows_utils import (
+    close_stale_connections,
+    django_db_flow,
+    django_db_task,
+)
 
 
 @django_db_task()
@@ -16,6 +23,113 @@ def count_ena_studies() -> int:
 @task
 def count_ena_studies_prefect() -> int:
     return Study.objects.count()
+
+
+@django_db_task
+def add_one(value: int) -> int:
+    return value + 1
+
+
+@django_db_task(name="add two with kwargs")
+def add_two(value: int) -> int:
+    return value + 2
+
+
+@django_db_flow
+def bare_django_db_flow(value: str) -> str:
+    return value.upper()
+
+
+@django_db_flow(name="django db flow with kwargs")
+def keyword_django_db_flow(value: str) -> str:
+    return value.upper()
+
+
+@django_db_task
+async def async_add_one(value: int) -> int:
+    return value + 1
+
+
+@django_db_flow
+async def async_uppercase(value: str) -> str:
+    return value.upper()
+
+
+@patch("workflows.prefect_utils.flows_utils.connections.all")
+def test_close_stale_connections_skips_atomic_connections(mock_connections_all):
+    healthy_conn = MagicMock(in_atomic_block=False)
+    atomic_conn = MagicMock(in_atomic_block=True)
+    mock_connections_all.return_value = [healthy_conn, atomic_conn]
+
+    close_stale_connections()
+
+    healthy_conn.close_if_unusable_or_obsolete.assert_called_once_with()
+    atomic_conn.close_if_unusable_or_obsolete.assert_not_called()
+
+
+@patch("workflows.prefect_utils.flows_utils.close_stale_connections")
+def test_django_db_task_supports_bare_decorator(
+    mock_close_stale_connections, prefect_harness
+):
+    assert isinstance(add_one, Task)
+    assert add_one(4) == 5
+
+    mock_close_stale_connections.assert_called_once_with()
+
+
+@patch("workflows.prefect_utils.flows_utils.close_stale_connections")
+def test_django_db_flow_supports_bare_decorator(
+    mock_close_stale_connections, prefect_harness
+):
+    assert isinstance(bare_django_db_flow, Flow)
+    assert bare_django_db_flow("blue") == "BLUE"
+
+    mock_close_stale_connections.assert_called_once_with()
+
+
+@patch("workflows.prefect_utils.flows_utils.close_stale_connections")
+def test_django_db_flow_supports_keyword_decorator(
+    mock_close_stale_connections, prefect_harness
+):
+    assert isinstance(keyword_django_db_flow, Flow)
+    assert keyword_django_db_flow("green") == "GREEN"
+
+    mock_close_stale_connections.assert_called_once_with()
+
+
+@patch("workflows.prefect_utils.flows_utils.close_stale_connections")
+def test_django_db_task_supports_keyword_decorator(
+    mock_close_stale_connections, prefect_harness
+):
+    assert isinstance(add_two, Task)
+    result = add_two(4)
+
+    assert result == 6
+    mock_close_stale_connections.assert_called_once_with()
+
+
+@patch("workflows.prefect_utils.flows_utils.close_stale_connections")
+@pytest.mark.asyncio
+async def test_django_db_task_preserves_async_callables(
+    mock_close_stale_connections, prefect_harness
+):
+    assert isinstance(async_add_one, Task)
+    assert async_add_one.isasync
+    assert await async_add_one(4) == 5
+
+    mock_close_stale_connections.assert_called_once_with()
+
+
+@patch("workflows.prefect_utils.flows_utils.close_stale_connections")
+@pytest.mark.asyncio
+async def test_django_db_flow_preserves_async_callables(
+    mock_close_stale_connections, prefect_harness
+):
+    assert isinstance(async_uppercase, Flow)
+    assert async_uppercase.isasync
+    assert await async_uppercase("red") == "RED"
+
+    mock_close_stale_connections.assert_called_once_with()
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Also patches the django_db_{flow,task} to be able to use them with no aguments.

Codex helped me with the code

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
