### PR TITLE
Don't persist {asa,virify,map}_results - we don't need them

### DIFF
--- a/workflows/flows/analysis/assembly/flows/run_assembly_analysis_pipeline_batch.py
+++ b/workflows/flows/analysis/assembly/flows/run_assembly_analysis_pipeline_batch.py
@@ -49,6 +49,7 @@ from workflows.flows.analysis.assembly.utils.status_update_hooks import (
     on_cancellation=[update_batch_status_counts],
     retries=2,
     retry_delay_seconds=60,
+    persist_result=False,
 )
 def run_assembly_batch(
     assembly_analyses_batch_id: uuid.UUID,

--- a/workflows/flows/analysis/assembly/flows/run_map_batch.py
+++ b/workflows/flows/analysis/assembly/flows/run_map_batch.py
@@ -43,6 +43,7 @@ from workflows.flows.analyse_study_tasks.cleanup_pipeline_directories import (
     on_cancellation=[update_batch_status_counts],
     retries=2,
     retry_delay_seconds=60,
+    persist_result=False,
 )
 def run_map_batch(assembly_analyses_batch_id: uuid.UUID):
     """

--- a/workflows/flows/analysis/assembly/flows/run_virify_batch.py
+++ b/workflows/flows/analysis/assembly/flows/run_virify_batch.py
@@ -40,6 +40,7 @@ from workflows.flows.analyse_study_tasks.cleanup_pipeline_directories import (
     on_cancellation=[update_batch_status_counts],
     retries=2,
     retry_delay_seconds=60,
+    persist_result=False,
 )
 def run_virify_batch(assembly_analyses_batch_id: uuid.UUID):
     """


### PR DESCRIPTION
The run_batch flows handle re-executions, so we don't need prefect to handle that. I bumped in to the case where I needed to re-run the asa flow to get the results ingested (because the flow died after nextflow ran but it could'nt save the orchestrated job in the db - timeout). So the flow was marked as done but the results never imported. I re-run the run_assembly_batch thingy but prefect refused to do so, as the previuos flow as marked as done. This shouldn't really happen, as we shouldn't get more timeouts now but it could happen again the future (db connections and stuff).

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [ ] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
