### PR TITLE
EMG-9743 Support mixed version pipelines, e.g. v6.1 for Amplicon

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -134,7 +134,7 @@ fileignoreconfig:
 - filename: workflows/ena_utils/ena_auth.py
   checksum: e8122d8429dad2fcb68f7fe2f5c6068d077ebb7707653eb61dd9a5ef54d2137f
 
-- filename: workflows/flows/analyse_study_tasks/make_samplesheet_amplicon.py
+- filename: workflows/flows/analyse_study_tasks/amplicon/make_samplesheet_amplicon.py
   allowed_patterns: [key]
 
 - filename: workflows/flows/analyse_study_tasks/make_samplesheet_assembly.py

--- a/analyses/fixtures/analysis/conftest.py
+++ b/analyses/fixtures/analysis/conftest.py
@@ -251,6 +251,68 @@ def amplicon_analysis_with_downloads(
 @patch(
     "workflows.flows.analyse_study_tasks.shared.copy_v6_pipeline_results.run_deployment"
 )
+def amplicon_analysis_with_downloads_v6_1(
+    mock_run_deployment,
+    raw_reads_mgnify_study,
+    raw_reads_mgnify_sample,
+):
+    sample = raw_reads_mgnify_sample[0]
+    study = raw_reads_mgnify_study
+    mock_run_deployment.return_value = Mock(id="mock-flow-run-id")
+
+    run = Run.objects.create(
+        ena_accessions=["SRR1111111"],
+        study=study,
+        ena_study=study.ena_study,
+        sample=sample,
+        experiment_type=Run.ExperimentTypes.AMPLICON,
+        metadata={
+            Run.CommonMetadataKeys.FASTQ_FTPS: ["ftp://example.org/SRR1111111.fastq"]
+        },
+    )
+
+    analysis = Analysis.objects.create(
+        ena_study=study.ena_study,
+        study=study,
+        experiment_type=Run.ExperimentTypes.AMPLICON,
+        sample=sample,
+        run=run,
+        pipeline_version=Analysis.PipelineVersions.v6_1,
+    )
+    analysis.mark_status(analysis.AnalysisStates.ANALYSIS_COMPLETED)
+
+    analysis.pipeline_outdir = "/app/data/tests/amplicon_v6_output"
+    analysis.results_dir = "/app/data/tests/amplicon_v6_output/SRR1111111"
+    analysis.metadata[analysis.KnownMetadataKeys.MARKER_GENE_SUMMARY] = {
+        analysis.CLOSED_REFERENCE: {
+            "marker_genes": {
+                "SSU": {
+                    "Archaea": {"read_count": 65, "majority_marker": True},
+                    "Eukarya": {"read_count": 0, "majority_marker": True},
+                    "Bacteria": {"read_count": 28655, "majority_marker": True},
+                }
+            }
+        },
+        analysis.ASV: {
+            "amplified_regions": [
+                {
+                    "asv_count": 94,
+                    "read_count": 16664,
+                    "marker_gene": "16S",
+                    "amplified_region": "V3-V4",
+                }
+            ]
+        },
+    }
+    analysis.save()
+    import_completed_amplicon_analysis(analysis)
+    return analysis
+
+
+@pytest.fixture
+@patch(
+    "workflows.flows.analyse_study_tasks.shared.copy_v6_pipeline_results.run_deployment"
+)
 def assembly_analysis_with_downloads(mock_run_deployment, assembly_analysis):
     mock_run_deployment.return_value = Mock(id="mock-flow-run-id")
 

--- a/analyses/management/commands/add_pipeline_to_study_downloads_download_groups.py
+++ b/analyses/management/commands/add_pipeline_to_study_downloads_download_groups.py
@@ -1,10 +1,20 @@
 from django.core.management.base import BaseCommand
-from analyses.models import Study
+from analyses.models import Study, Analysis
 from analyses.base_models.with_experiment_type_models import WithExperimentTypeModel
 
 
 class Command(BaseCommand):
     help = "Update the download_group for all Study downloads to include the pipeline version and type."
+
+    @staticmethod
+    def _infer_pipeline_version(analyses, inferred_type: str) -> str:
+        if inferred_type == "amplicon":
+            pipeline_versions = set(analyses.values_list("pipeline_version", flat=True))
+            if Analysis.PipelineVersions.v6_1 in pipeline_versions:
+                return "v6.1"
+            if Analysis.PipelineVersions.v6 in pipeline_versions:
+                return "v6"
+        return "v6"
 
     def handle(self, *args, **options):
         # Filter studies with non-empty downloads list. In Django JSONField, we can exclude []
@@ -58,7 +68,7 @@ class Command(BaseCommand):
                 continue
 
             updated = False
-            version = "v6"
+            version = self._infer_pipeline_version(analyses, inferred_type)
 
             for download in study.downloads:
                 current_group = download.get("download_group", "")

--- a/analyses/migrations/0057_analysis_pipeline_version_v6_1.py
+++ b/analyses/migrations/0057_analysis_pipeline_version_v6_1.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("analyses", "0056_samplerelatedsample_sample_related_samples_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="analysis",
+            name="pipeline_version",
+            field=models.CharField(
+                choices=[
+                    ("V1", "v1.0"),
+                    ("V2", "v2.0"),
+                    ("V3", "v3.0"),
+                    ("V4", "v4.0"),
+                    ("V4.1", "v4.1"),
+                    ("V5", "v5.0"),
+                    ("V6", "v6.0"),
+                    ("V6.1", "v6.1"),
+                ],
+                default="V6",
+                max_length=5,
+            ),
+        ),
+    ]

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -930,16 +930,10 @@ class Analysis(
     def pipeline_version_from_config(
         cls, pipeline_version: str
     ) -> "Analysis.PipelineVersions":
-        normalized = pipeline_version.strip().lower()
-        version_map = {
-            cls.PipelineVersions.v6.label.lower(): cls.PipelineVersions.v6.value,
-            "v6": cls.PipelineVersions.v6.value,
-            cls.PipelineVersions.v6_1.label.lower(): cls.PipelineVersions.v6_1.value,
-            "v6.1": cls.PipelineVersions.v6_1.value,
-        }
+        normalized = pipeline_version.strip().lower().rstrip(".0")
         try:
-            return cls.PipelineVersions(version_map[normalized])
-        except KeyError as exc:
+            return getattr(cls.PipelineVersions, normalized)
+        except AttributeError as exc:
             raise ValueError(
                 f"Unsupported pipeline version {pipeline_version!r}"
             ) from exc

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -913,12 +913,36 @@ class Analysis(
     metadata = models.JSONField(default=dict, blank=True)
 
     class PipelineVersions(models.TextChoices):
+        v1 = "V1", "v1.0"
+        v2 = "V2", "v2.0"
+        v3 = "V3", "v3.0"
+        v4 = "V4", "v4.0"
+        v4_1 = "V4.1", "v4.1"
         v5 = "V5", "v5.0"
         v6 = "V6", "v6.0"
+        v6_1 = "V6.1", "v6.1"
 
     pipeline_version = models.CharField(
         choices=PipelineVersions, max_length=5, default=PipelineVersions.v6
     )
+
+    @classmethod
+    def pipeline_version_from_config(
+        cls, pipeline_version: str
+    ) -> "Analysis.PipelineVersions":
+        normalized = pipeline_version.strip().lower()
+        version_map = {
+            cls.PipelineVersions.v6.label.lower(): cls.PipelineVersions.v6.value,
+            "v6": cls.PipelineVersions.v6.value,
+            cls.PipelineVersions.v6_1.label.lower(): cls.PipelineVersions.v6_1.value,
+            "v6.1": cls.PipelineVersions.v6_1.value,
+        }
+        try:
+            return cls.PipelineVersions(version_map[normalized])
+        except KeyError as exc:
+            raise ValueError(
+                f"Unsupported pipeline version {pipeline_version!r}"
+            ) from exc
 
     class AnalysisStates(FutureStrEnum):
         # TODO: this is pipeline specific - I think we need to move elsewhere or refactor (mbc)

--- a/analyses/tests/test_add_pipeline_to_study_downloads_download_groups.py
+++ b/analyses/tests/test_add_pipeline_to_study_downloads_download_groups.py
@@ -30,6 +30,7 @@ def test_add_pipeline_to_study_downloads_download_groups(
         run=run,
         ena_study=raw_reads_mgnify_study.ena_study,
         experiment_type=WithExperimentTypeModel.ExperimentTypes.AMPLICON,
+        pipeline_version=Analysis.PipelineVersions.v6_1,
     )
     # Test with both "study_summary.suffix" and just "study_summary"
     amplicon_study.add_download(
@@ -182,9 +183,11 @@ def test_add_pipeline_to_study_downloads_download_groups(
     amplicon_study.refresh_from_db()
     assert (
         amplicon_study.downloads[0]["download_group"]
-        == "study_summary.v6.amplicon.silva-ssu"
+        == "study_summary.v6.1.amplicon.silva-ssu"
     )
-    assert amplicon_study.downloads[1]["download_group"] == "study_summary.v6.amplicon"
+    assert (
+        amplicon_study.downloads[1]["download_group"] == "study_summary.v6.1.amplicon"
+    )
 
     assembly_study.refresh_from_db()
     assert (
@@ -207,3 +210,44 @@ def test_add_pipeline_to_study_downloads_download_groups(
 
     nodl_study.refresh_from_db()
     assert nodl_study.downloads == []
+
+
+@pytest.mark.django_db
+def test_add_pipeline_to_study_downloads_download_groups_amplicon_v6_1(
+    raw_reads_mgnify_study, raw_reads_mgnify_sample, raw_read_run
+):
+    sample = raw_reads_mgnify_sample[0]
+    run = raw_read_run[0]
+
+    study = Study.objects.create(
+        accession="MGYS00001007",
+        title="Amplicon Study v6.1",
+        ena_study=raw_reads_mgnify_study.ena_study,
+    )
+    Analysis.objects.create(
+        accession="MGYA00001007",
+        study=study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.AMPLICON,
+        pipeline_version=Analysis.PipelineVersions.v6_1,
+    )
+    study.add_download(
+        DownloadFile(
+            path="s7.tsv",
+            alias="a7",
+            download_type=DownloadType.TAXONOMIC_ANALYSIS,
+            file_type=DownloadFileType.TSV,
+            download_group="study_summary.silva-ssu",
+            short_description="short",
+            long_description="long",
+        )
+    )
+
+    call_command("add_pipeline_to_study_downloads_download_groups")
+
+    study.refresh_from_db()
+    assert (
+        study.downloads[0]["download_group"] == "study_summary.v6.1.amplicon.silva-ssu"
+    )

--- a/emgapiv2/api/studies.py
+++ b/emgapiv2/api/studies.py
@@ -43,7 +43,7 @@ class StudyListFilters(BiomeFilter):
     def filter_has_analyses_from_pipeline(self, version: str | None) -> Q:
         if not version:
             return Q()
-        if version == analyses.models.Analysis.PipelineVersions.v6:
+        if version.lower().startswith("v6"):
             return Q(features__has_v6_analyses=True)
         if version == analyses.models.Analysis.PipelineVersions.v5:
             # TODO

--- a/workflows/flows/analyse_study_tasks/amplicon/make_samplesheet_amplicon.py
+++ b/workflows/flows/analyse_study_tasks/amplicon/make_samplesheet_amplicon.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from textwrap import dedent as _
 
 from django.db.models import QuerySet
+from django.utils.text import slugify
 from prefect.artifacts import create_table_artifact
 
 from activate_django_first import EMG_CONFIG
@@ -33,6 +34,8 @@ def make_samplesheet_amplicon(runs: QuerySet, samplesheet_path: Path) -> Path:
     :return: Tuple of the Path to the samplesheet file, and a hash of the run IDs which is used in the SS filename.
     """
 
+    pipeline_version = EMG_CONFIG.amplicon_pipeline.pipeline_version
+
     sample_sheet_csv = queryset_to_samplesheet(
         queryset=runs,
         filename=samplesheet_path,
@@ -62,11 +65,11 @@ def make_samplesheet_amplicon(runs: QuerySet, samplesheet_path: Path) -> Path:
         table = list(csv_reader)
 
     create_table_artifact(
-        key="amplicon-v6-initial-sample-sheet",
+        key=slugify(f"amplicon-{pipeline_version}-initial-sample-sheet"),
         table=table,
         description=_(
             f"""\
-            Sample sheet created for run of amplicon-v6.
+            Sample sheet created for run of amplicon-{pipeline_version}.
             Saved to `{sample_sheet_csv}`
             **Warning!** This table is the *initial* content of the samplesheet, when it was first made. Any edits made since are not shown here.
             [Edit it]({EMG_CONFIG.service_urls.app_root}/workflows/edit-samplesheet/fetch/{encode_samplesheet_path(sample_sheet_csv)})

--- a/workflows/flows/analyse_study_tasks/amplicon/run_amplicon_pipeline_via_samplesheet.py
+++ b/workflows/flows/analyse_study_tasks/amplicon/run_amplicon_pipeline_via_samplesheet.py
@@ -44,7 +44,7 @@ from workflows.flows.analyse_study_tasks.cleanup_pipeline_directories import (
 from workflows.nextflow_utils.samplesheets import queryset_hash
 
 
-@flow(name="Run analysis pipeline-v6 via samplesheet", log_prints=True)
+@flow(name="Run amplicon analysis pipeline via samplesheet", log_prints=True)
 def run_amplicon_pipeline_via_samplesheet(
     mgnify_study: analyses.models.Study,
     amplicon_analysis_ids: List[Union[str, int]],

--- a/workflows/flows/analyse_study_tasks/shared/copy_v6_pipeline_results.py
+++ b/workflows/flows/analyse_study_tasks/shared/copy_v6_pipeline_results.py
@@ -28,8 +28,8 @@ from workflows.prefect_utils.flows_utils import django_db_task as task
 
 
 @task(
-    name="Copy V6 Pipeline Results",
-    task_run_name="Copy V6 Pipeline Results for {analysis_accession}",
+    name="Copy Pipeline Results",
+    task_run_name="Copy Pipeline Results for {analysis_accession}",
 )
 def copy_v6_pipeline_results(analysis_accession: str, timeout: int = 14400):
     """
@@ -117,7 +117,7 @@ def copy_v6_pipeline_results(analysis_accession: str, timeout: int = 14400):
     analysis.save()
 
 
-@task(name="Copy V6 Study Summaries")
+@task(name="Copy Study Summaries")
 def copy_v6_study_summaries(
     study_accession: str,
     analysis_type: AnalysisType = AnalysisType.AMPLICON,
@@ -127,7 +127,7 @@ def copy_v6_study_summaries(
     Copy study summaries from a pipeline's results subdirectory to external results dir.
 
     The source directory is computed from ``study.results_dir`` and the pipeline config
-    for the given ``analysis_type``, e.g. ``{results_dir}/amplicon_v6/``.
+    for the given ``analysis_type``, e.g. ``{results_dir}/amplicon_v6.1/``.
     This matches the directory layout produced by :func:`merge_study_summaries`.
 
     :param study_accession: The accession of the study to copy summaries for.

--- a/workflows/flows/analyse_study_tasks/shared/create_analyses.py
+++ b/workflows/flows/analyse_study_tasks/shared/create_analyses.py
@@ -26,7 +26,7 @@ def create_analyses(
     Get or create analysis objects for each run in the study that matches the given experiment type.
     :param study: An MGYS study that already has runs to be analysed attached.
     :param for_experiment_type: E.g. AMPLICON or WGS
-    :param pipeline: Pipeline version e.g. v6
+    :param pipeline: Pipeline version e.g. v6 or v6.1
     :param ena_library_strategy_policy: Optional policy for handling runs in the study that aren't labeled as for_experiment_type.
     :return: List of matching/created analysis objects.
     """

--- a/workflows/flows/analyse_study_tasks/shared/dwcr_generator.py
+++ b/workflows/flows/analyse_study_tasks/shared/dwcr_generator.py
@@ -245,7 +245,7 @@ def add_dwcr_summaries_to_downloads(mgnify_study_accession: str):
                 DownloadFile(
                     path=Path("study-summaries") / summary_file.name,
                     download_type=DownloadType.TAXONOMIC_ANALYSIS,
-                    download_group="study_summary",
+                    download_group=f"study_summary.{pipeline_config.pipeline_version}.{pipeline_config.pipeline_name}",
                     file_type=DownloadFileType.CSV,
                     short_description=f"DwC-Ready summary of closed-ref taxonomies using {db} as ref DB",
                     long_description=f"DwC-Ready summary of closed-reference taxonomies using {db} as ref DB, across all runs in the study",

--- a/workflows/flows/analyse_study_tasks/shared/get_analyses_to_attempt.py
+++ b/workflows/flows/analyse_study_tasks/shared/get_analyses_to_attempt.py
@@ -19,12 +19,14 @@ def get_analyses_to_attempt(
             analyses.base_models.with_experiment_type_models.WithExperimentTypeModel.ExperimentTypes
         ],
     ],
+    pipeline: analyses.models.Analysis.PipelineVersions | None = None,
     ena_library_strategy_policy: ENALibraryStrategyPolicy = ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
 ) -> List[Union[str, int]]:
     """
     Determine the list of runs worth trying currently for this study.
     :param study: MGYS study to look for to-be-completed analyses in
     :param for_experiment_type: E.g. AMPLICON or WGS.
+    :param pipeline: Optional pipeline version to limit analyses to.
     :param ena_library_strategy_policy: Optional policy for handling runs in the study that aren't labeled as for_experiment_type.
     :return: List of analysis object IDs
     """
@@ -40,6 +42,8 @@ def get_analyses_to_attempt(
             analyses.models.Analysis.AnalysisStates.ANALYSIS_ANNOTATIONS_IMPORTED,
         ]
     )
+    if pipeline is not None:
+        analyses_worth_trying = analyses_worth_trying.filter(pipeline_version=pipeline)
 
     if ena_library_strategy_policy == ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA:
         analyses_worth_trying = analyses_worth_trying.filter(

--- a/workflows/flows/analyse_study_tasks/shared/markergene_study_summary.py
+++ b/workflows/flows/analyse_study_tasks/shared/markergene_study_summary.py
@@ -18,6 +18,9 @@ from workflows.data_io_utils.file_rules.common_rules import (
 )
 from workflows.data_io_utils.file_rules.nodes import Directory, File
 from workflows.prefect_utils.flows_utils import django_db_flow as flow
+from workflows.flows.analysis.pipeline_versions import (
+    get_current_pipeline_version_for_experiment_type,
+)
 from workflows.prefect_utils.dir_context import chdir
 
 STUDY_SUMMARY = "study_summary"
@@ -32,7 +35,7 @@ def generate_markergene_summary_for_pipeline_run(
 ):
     """
     Generate a markergene summary file for an analysis pipeline execution,
-    e.g. a run of the V6 Amplicon pipeline on a samplesheet of runs.
+    e.g. a run of the configured amplicon pipeline on a samplesheet of runs.
 
     :param mgnify_study_accession: e.g. MGYS0000001
     :param pipeline_outdir: The path to dir where pipeline published results are, e.g. /nfs/my/dir/abcedfg
@@ -41,6 +44,9 @@ def generate_markergene_summary_for_pipeline_run(
     """
     logger = get_run_logger()
     study = Study.objects.get(accession=mgnify_study_accession)
+    amplicon_pipeline_version = get_current_pipeline_version_for_experiment_type(
+        Analysis.ExperimentTypes.AMPLICON
+    )
     logger.info(f"Generating marker gene summaries for a pipeline execution of {study}")
 
     results_dir = Directory(
@@ -101,7 +107,7 @@ def generate_markergene_summary_for_pipeline_run(
         }
         analysis = study.analyses.get(
             run__ena_accessions__icontains=run_accession,
-            pipeline_version=Analysis.PipelineVersions.v6,
+            pipeline_version=amplicon_pipeline_version,
         )
         analysis.metadata[analysis.KnownMetadataKeys.MARKER_GENE_SUMMARY] = (
             marker_gene_summary_for_run

--- a/workflows/flows/analysis/pipeline_versions.py
+++ b/workflows/flows/analysis/pipeline_versions.py
@@ -1,7 +1,7 @@
 from activate_django_first import EMG_CONFIG
 
 from analyses.models import Analysis
-
+from emgapiv2.config import MGnifyPipelineConfig
 
 PIPELINE_CONFIGS_BY_EXPERIMENT_TYPE = {
     Analysis.ExperimentTypes.AMPLICON: EMG_CONFIG.amplicon_pipeline,
@@ -15,7 +15,7 @@ PIPELINE_CONFIGS_BY_EXPERIMENT_TYPE = {
 
 def get_pipeline_config_for_experiment_type(
     experiment_type: Analysis.ExperimentTypes | str,
-):
+) -> MGnifyPipelineConfig:
     normalized_experiment_type = (
         experiment_type
         if isinstance(experiment_type, Analysis.ExperimentTypes)
@@ -34,6 +34,7 @@ def get_current_pipeline_version_for_experiment_type(
 def get_v6_family_pipeline_versions_for_experiment_type(
     experiment_type: Analysis.ExperimentTypes | str,
 ) -> tuple[Analysis.PipelineVersions, ...]:
+    # TODO: remove after all legacy data are imported
     normalized_experiment_type = (
         experiment_type
         if isinstance(experiment_type, Analysis.ExperimentTypes)

--- a/workflows/flows/analysis/pipeline_versions.py
+++ b/workflows/flows/analysis/pipeline_versions.py
@@ -1,0 +1,44 @@
+from activate_django_first import EMG_CONFIG
+
+from analyses.models import Analysis
+
+
+PIPELINE_CONFIGS_BY_EXPERIMENT_TYPE = {
+    Analysis.ExperimentTypes.AMPLICON: EMG_CONFIG.amplicon_pipeline,
+    Analysis.ExperimentTypes.METAGENOMIC: EMG_CONFIG.rawreads_pipeline,
+    Analysis.ExperimentTypes.METATRANSCRIPTOMIC: EMG_CONFIG.rawreads_pipeline,
+    Analysis.ExperimentTypes.ASSEMBLY: EMG_CONFIG.assembly_analysis_pipeline,
+    Analysis.ExperimentTypes.HYBRID_ASSEMBLY: EMG_CONFIG.assembly_analysis_pipeline,
+    Analysis.ExperimentTypes.LONG_READ_ASSEMBLY: EMG_CONFIG.assembly_analysis_pipeline,
+}
+
+
+def get_pipeline_config_for_experiment_type(
+    experiment_type: Analysis.ExperimentTypes | str,
+):
+    normalized_experiment_type = (
+        experiment_type
+        if isinstance(experiment_type, Analysis.ExperimentTypes)
+        else Analysis.ExperimentTypes(experiment_type)
+    )
+    return PIPELINE_CONFIGS_BY_EXPERIMENT_TYPE[normalized_experiment_type]
+
+
+def get_current_pipeline_version_for_experiment_type(
+    experiment_type: Analysis.ExperimentTypes | str,
+) -> Analysis.PipelineVersions:
+    pipeline_config = get_pipeline_config_for_experiment_type(experiment_type)
+    return Analysis.pipeline_version_from_config(pipeline_config.pipeline_version)
+
+
+def get_v6_family_pipeline_versions_for_experiment_type(
+    experiment_type: Analysis.ExperimentTypes | str,
+) -> tuple[Analysis.PipelineVersions, ...]:
+    normalized_experiment_type = (
+        experiment_type
+        if isinstance(experiment_type, Analysis.ExperimentTypes)
+        else Analysis.ExperimentTypes(experiment_type)
+    )
+    if normalized_experiment_type == Analysis.ExperimentTypes.AMPLICON:
+        return (Analysis.PipelineVersions.v6, Analysis.PipelineVersions.v6_1)
+    return (Analysis.PipelineVersions.v6,)

--- a/workflows/flows/analysis_amplicon_study.py
+++ b/workflows/flows/analysis_amplicon_study.py
@@ -37,6 +37,10 @@ from workflows.ena_utils.ena_api_requests import (
 )
 from workflows.ena_utils.webin_owner_utils import validate_and_set_webin_owner
 from workflows.flows.analysis import AnalysisType
+from workflows.flows.analysis.pipeline_versions import (
+    get_current_pipeline_version_for_experiment_type,
+    get_v6_family_pipeline_versions_for_experiment_type,
+)
 from workflows.flows.analyse_study_tasks.shared.study_summary import (
     merge_study_summaries,
     add_study_summaries_to_downloads,
@@ -56,17 +60,20 @@ _AMPLICON = "AMPLICON"
 
 
 @flow(
-    name="Run analysis pipeline-v6 on amplicon study",
+    name="Run amplicon analysis pipeline on study",
     log_prints=True,
     flow_run_name="Analyse amplicon: {study_accession}",
 )
 def analysis_amplicon_study(study_accession: str):
     """
     Get a study from ENA, and input it to MGnify.
-    Kick off amplicon-v6 pipeline.
+    Kick off the configured amplicon pipeline.
     :param study_accession: Study accession e.g. PRJxxxxxx
     """
     logger = get_run_logger()
+    amplicon_pipeline_version = get_current_pipeline_version_for_experiment_type(
+        analyses.models.Analysis.ExperimentTypes.AMPLICON
+    )
     # Create/get ENA Study object
     ena_study = ena.models.Study.objects.get_ena_study(study_accession)
     if not ena_study:
@@ -118,9 +125,9 @@ def analysis_amplicon_study(study_accession: str):
         wait_for_input=AnalyseStudyInput.with_initial_data(
             description=_(
                 f"""\
-                **Amplicon V6**
+                **Amplicon {amplicon_pipeline_version.label}**
                 This will analyse all {len(read_runs)} amplicon read-runs of study {ena_study.accession} \
-                using [Amplicon Pipeline V6](https://github.com/ebi-metagenomics/amplicon-pipeline).
+                using [Amplicon Pipeline {amplicon_pipeline_version.label.upper()}](https://github.com/ebi-metagenomics/amplicon-pipeline).
 
                 **Read-run filtering**
                 If you expected more than {len(read_runs)} amplicon read-runs, you can add other (incorrect) \
@@ -177,7 +184,7 @@ def analysis_amplicon_study(study_accession: str):
     create_analyses(
         mgnify_study,
         for_experiment_type=analyses.base_models.with_experiment_type_models.WithExperimentTypeModel.ExperimentTypes.AMPLICON,
-        pipeline=analyses.models.Analysis.PipelineVersions.v6,
+        pipeline=amplicon_pipeline_version,
         ena_library_strategy_policy=analyse_study_input.library_strategy_policy,
     )
     ena_study.save()  # just for safety, propagate privacy state/owner from study to new analyses etc.
@@ -185,6 +192,7 @@ def analysis_amplicon_study(study_accession: str):
     analyses_to_attempt = get_analyses_to_attempt(
         mgnify_study,
         for_experiment_type=analyses.base_models.with_experiment_type_models.WithExperimentTypeModel.ExperimentTypes.AMPLICON,
+        pipeline=amplicon_pipeline_version,
         ena_library_strategy_policy=analyse_study_input.library_strategy_policy,
     )
 
@@ -233,7 +241,10 @@ def analysis_amplicon_study(study_accession: str):
 
     mgnify_study.refresh_from_db()
     mgnify_study.features.has_v6_analyses = mgnify_study.analyses.filter(
-        pipeline_version=analyses.models.Analysis.PipelineVersions.v6, is_ready=True
+        pipeline_version__in=get_v6_family_pipeline_versions_for_experiment_type(
+            analyses.models.Analysis.ExperimentTypes.AMPLICON
+        ),
+        is_ready=True,
     ).exists()
     mgnify_study.save()
 

--- a/workflows/flows/analysis_amplicon_study.py
+++ b/workflows/flows/analysis_amplicon_study.py
@@ -246,6 +246,7 @@ def analysis_amplicon_study(study_accession: str):
         ),
         is_ready=True,
     ).exists()
+    # TODO: remove has_v6_analyses from features json once all legacy data imported
     mgnify_study.save()
 
     emit_event(

--- a/workflows/tests/test_analysis_amplicon_study_flow.py
+++ b/workflows/tests/test_analysis_amplicon_study_flow.py
@@ -1179,7 +1179,9 @@ def test_prefect_analyse_amplicon_flow(
     mock_suspend_flow_run.assert_called()
 
     # Check samplesheet
-    assembly_samplesheet_table = Artifact.get("amplicon-v6-initial-sample-sheet")
+    assembly_samplesheet_table = Artifact.get(
+        f"amplicon-{EMG_CONFIG.amplicon_pipeline.pipeline_version}-initial-sample-sheet"
+    )
     assert assembly_samplesheet_table.type == "table"
     table_data = json.loads(assembly_samplesheet_table.data)
     assert len(table_data) == len(runs)
@@ -1710,7 +1712,9 @@ def test_prefect_analyse_amplicon_flow_private_data(
     mock_check_cluster_job_all_completed.assert_called()
     mock_suspend_flow_run.assert_called()
 
-    assembly_samplesheet_table = Artifact.get("amplicon-v6-initial-sample-sheet")
+    assembly_samplesheet_table = Artifact.get(
+        f"amplicon-{EMG_CONFIG.amplicon_pipeline.pipeline_version}-initial-sample-sheet"
+    )
     assert assembly_samplesheet_table.type == "table"
     table_data = json.loads(assembly_samplesheet_table.data)
     assert len(table_data) == len(runs)

--- a/workflows/tests/test_copy_amplicon_pipeline_results.py
+++ b/workflows/tests/test_copy_amplicon_pipeline_results.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from analyses.models import Analysis
 from workflows.data_io_utils.filenames import trailing_slash_ensured_dir
 from workflows.data_io_utils.mgnify_v6_utils.amplicon import EMG_CONFIG
 from workflows.flows.analyse_study_tasks.shared.copy_v6_pipeline_results import (
@@ -83,6 +84,28 @@ def test_copy_amplicon_pipeline_results(raw_read_analyses, prefect_harness):
         job_variables = call_kwargs["job_variables"]
         assert "partition" in job_variables
         assert job_variables["partition"] == EMG_CONFIG.slurm.datamover_partition
+
+
+@pytest.mark.django_db(transaction=True)
+def test_copy_amplicon_pipeline_results_v6_1(
+    amplicon_analysis_with_downloads_v6_1, prefect_harness
+):
+    analysis = amplicon_analysis_with_downloads_v6_1
+
+    mock_run_deployment = Mock(return_value=Mock(id="mock-flow-run-id"))
+
+    with patch(
+        "workflows.flows.analyse_study_tasks.shared.copy_v6_pipeline_results.run_deployment",
+        mock_run_deployment,
+    ):
+        copy_v6_pipeline_results(analysis.accession)
+
+    parameters = mock_run_deployment.call_args.kwargs["parameters"]
+    assert parameters["source"] == trailing_slash_ensured_dir(analysis.results_dir)
+    assert f"/{Analysis.PipelineVersions.v6_1}/amplicon" in parameters["target"]
+
+    analysis.refresh_from_db()
+    assert str(analysis.external_results_dir).endswith("/V6.1/amplicon")
 
 
 @pytest.mark.django_db(transaction=True)

--- a/workflows/tests/test_copy_v6_study_summaries.py
+++ b/workflows/tests/test_copy_v6_study_summaries.py
@@ -109,3 +109,34 @@ class TestCopyV6StudySummaries:
 
         study.refresh_from_db()
         assert study.external_results_dir is None
+
+    @patch(
+        "workflows.flows.analyse_study_tasks.shared.copy_v6_pipeline_results.run_deployment"
+    )
+    def test_amplicon_uses_configured_pipeline_version_subdir(
+        self, mock_run_deployment, prefect_harness, tmp_path, monkeypatch
+    ):
+        mock_run_deployment.return_value = Mock(id="mock-flow-run-id")
+        monkeypatch.setattr(
+            "workflows.flows.analyse_study_tasks.shared.study_summary.EMG_CONFIG.amplicon_pipeline.pipeline_version",
+            "v6.1",
+        )
+
+        ena_study = ENAStudy.objects.create(accession="PRJEB12346", title="Test Study")
+        study = Study.objects.create(
+            ena_study=ena_study,
+            title="Test Study",
+            results_dir=str(tmp_path / "results"),
+        )
+        study.inherit_accessions_from_related_ena_object("ena_study")
+
+        pipeline_dir = study.results_dir_path / "amplicon_v6.1"
+        pipeline_dir.mkdir(parents=True)
+        (
+            pipeline_dir / f"{study.first_accession}_taxonomy_study_summary.tsv"
+        ).write_text("data\n")
+
+        copy_v6_study_summaries(study.accession, analysis_type=AnalysisType.AMPLICON)
+
+        source_path = mock_run_deployment.call_args.kwargs["parameters"]["source"]
+        assert source_path.rstrip("/") == str(pipeline_dir)

--- a/workflows/tests/test_get_analyses_to_attempt.py
+++ b/workflows/tests/test_get_analyses_to_attempt.py
@@ -1,0 +1,45 @@
+import pytest
+
+from analyses.base_models.with_experiment_type_models import WithExperimentTypeModel
+from analyses.models import Analysis
+from workflows.ena_utils.ena_api_requests import ENALibraryStrategyPolicy
+from workflows.flows.analyse_study_tasks.shared.get_analyses_to_attempt import (
+    get_analyses_to_attempt,
+)
+
+
+@pytest.mark.django_db
+def test_get_analyses_to_attempt_filters_to_requested_pipeline_version(
+    raw_reads_mgnify_study, raw_reads_mgnify_sample, raw_read_run
+):
+    sample = raw_reads_mgnify_sample[0]
+    run = raw_read_run[0]
+
+    analysis_v6 = Analysis.objects.create(
+        accession="MGYA00002001",
+        study=raw_reads_mgnify_study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.AMPLICON,
+        pipeline_version=Analysis.PipelineVersions.v6,
+    )
+    analysis_v6_1 = Analysis.objects.create(
+        accession="MGYA00002002",
+        study=raw_reads_mgnify_study,
+        sample=sample,
+        run=run,
+        ena_study=raw_reads_mgnify_study.ena_study,
+        experiment_type=WithExperimentTypeModel.ExperimentTypes.AMPLICON,
+        pipeline_version=Analysis.PipelineVersions.v6_1,
+    )
+
+    analyses_to_attempt = get_analyses_to_attempt.fn(
+        raw_reads_mgnify_study,
+        for_experiment_type=WithExperimentTypeModel.ExperimentTypes.AMPLICON,
+        pipeline=Analysis.PipelineVersions.v6_1,
+        ena_library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+    )
+
+    assert list(analyses_to_attempt) == [analysis_v6_1.id]
+    assert analysis_v6.id not in analyses_to_attempt


### PR DESCRIPTION
This PR:
* adds supported analysis pipeline versions for all legacy released version (v1.0 - v5.0)
* adds support for a v6 version family, removing some assumptions that all v6 pipelines would be in-sync.
  * this is because amplicon will shortly be v6.1 whilst raw-reads and assembly-analysis stay on v6.0

Codex-assisted.

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
