### PR TITLE
Sync samples with ena flow - WIP

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -213,6 +213,12 @@ fileignoreconfig:
 - filename: workflows/flows/housekeeping/clean_nextflow_workdirs.py
   allowed_patterns: [key]
 
+- filename: workflows/flows/housekeeping/sync_samples_with_ena.py
+  allowed_patterns: [key]
+
+- filename: workflows/flows/housekeeping/sync_studies_with_ena.py
+  allowed_patterns: [key]
+
 - filename: workflows/tests/test_flows_utils.py
   checksum: 7044790c62db033597a0c9391751a32f2db1f88d5ba5a953b6c607d97ff7ed6d
 

--- a/workflows/flows/housekeeping/sync_samples_with_ena.py
+++ b/workflows/flows/housekeeping/sync_samples_with_ena.py
@@ -1,0 +1,84 @@
+from prefect import get_run_logger
+
+from activate_django_first import EMG_CONFIG  # noqa: F401
+
+import ena.models
+from workflows.ena_utils.ena_api_requests import sync_sample_metadata_from_ena
+from workflows.prefect_utils.flows_utils import (
+    django_db_flow as flow,
+    django_db_task as task,
+)
+
+
+@task(name="Sync batch of samples metadata from ENA")
+def sync_samples(sample_accessions: list[str]) -> list[str]:
+    """Sync metadata for a batch of samples from ENA.
+
+    Each sample is synced individually with try/except so that a failure
+    for one sample does not block the rest of the batch.
+
+    :param sample_accessions: List of sample accessions to sync.
+    :return: List of accessions that failed to sync.
+    """
+    logger = get_run_logger()
+    failed = []
+    for sample_accession in sample_accessions:
+        try:
+            sample = ena.models.Sample.objects.get(accession=sample_accession)
+            logger.info(f"Syncing metadata for sample {sample.accession}")
+            sync_sample_metadata_from_ena(sample)
+            logger.info(f"Successfully synced metadata for sample {sample.accession}")
+        except Exception as e:
+            logger.error(f"Failed to sync sample {sample_accession}: {e}")
+            failed.append(sample_accession)
+    return failed
+
+
+@flow(flow_run_name="Sync samples with ENA")
+def sync_samples_with_ena(
+    accessions: list[str] | None = None,
+    all_samples: bool = False,
+    batch_size: int = 50,
+) -> list[str]:
+    """Sync sample metadata from ENA for a list of accessions or all samples.
+
+    Samples are processed in batches to avoid long-running DB connections.
+
+    :param accessions: List of sample accessions to sync.
+    :param all_samples: If True, sync all samples.
+    :param batch_size: Number of samples to process per batch (default 50).
+    :return: List of sample accessions that failed to sync.
+    """
+    logger = get_run_logger()
+
+    if accessions and all_samples:
+        raise ValueError("Cannot provide both accessions and all_samples")
+
+    if not accessions and not all_samples:
+        raise ValueError("Must provide either accessions or all_samples=True")
+
+    if accessions:
+        sample_accessions = accessions
+    else:
+        sample_accessions = list(
+            ena.models.Sample.objects.values_list("accession", flat=True)
+        )
+
+    total = len(sample_accessions)
+    logger.info(f"Syncing metadata for {total} samples in batches of {batch_size}")
+
+    all_failed = []
+    for i in range(0, total, batch_size):
+        batch = sample_accessions[i : i + batch_size]
+        logger.info(f"Processing batch {i // batch_size + 1} ({len(batch)} samples)")
+        failed = sync_samples(batch)
+        all_failed.extend(failed)
+
+    if all_failed:
+        logger.warning(
+            f"Failed to sync {len(all_failed)} samples: {', '.join(all_failed)}"
+        )
+    else:
+        logger.info("All samples synced successfully")
+
+    return all_failed

--- a/workflows/flows/housekeeping/sync_samples_with_ena.py
+++ b/workflows/flows/housekeeping/sync_samples_with_ena.py
@@ -1,4 +1,5 @@
 from prefect import get_run_logger
+from prefect.artifacts import create_table_artifact
 
 from activate_django_first import EMG_CONFIG  # noqa: F401
 
@@ -24,7 +25,11 @@ def sync_samples(sample_accessions: list[str]) -> list[str]:
     failed = []
     for sample_accession in sample_accessions:
         try:
-            sample = ena.models.Sample.objects.get(accession=sample_accession)
+            sample = ena.models.Sample.objects.get_ena_sample(sample_accession)
+            if sample is None:
+                raise ena.models.Sample.DoesNotExist(
+                    f"No sample found for accession {sample_accession}"
+                )
             logger.info(f"Syncing metadata for sample {sample.accession}")
             sync_sample_metadata_from_ena(sample)
             logger.info(f"Successfully synced metadata for sample {sample.accession}")
@@ -67,18 +72,25 @@ def sync_samples_with_ena(
     total = len(sample_accessions)
     logger.info(f"Syncing metadata for {total} samples in batches of {batch_size}")
 
-    all_failed = []
+    failed_accessions = []
     for i in range(0, total, batch_size):
         batch = sample_accessions[i : i + batch_size]
         logger.info(f"Processing batch {i // batch_size + 1} ({len(batch)} samples)")
         failed = sync_samples(batch)
-        all_failed.extend(failed)
+        if failed:
+            failed_accessions.extend(failed)
 
-    if all_failed:
+    if failed_accessions:
         logger.warning(
-            f"Failed to sync {len(all_failed)} samples: {', '.join(all_failed)}"
+            f"Failed to sync {len(failed_accessions)} samples. "
+            "See the 'failed-ena-sample-syncs' table artifact for accessions."
+        )
+        create_table_artifact(
+            key="failed-ena-sample-syncs",
+            table=[{"accession": accession} for accession in failed_accessions],
+            description=f"{len(failed_accessions)} samples failed to sync from ENA.",
         )
     else:
         logger.info("All samples synced successfully")
 
-    return all_failed
+    return failed_accessions

--- a/workflows/flows/housekeeping/sync_studies_with_ena.py
+++ b/workflows/flows/housekeeping/sync_studies_with_ena.py
@@ -1,4 +1,5 @@
 from prefect import get_run_logger
+from prefect.artifacts import create_table_artifact
 
 from activate_django_first import EMG_CONFIG  # noqa: F401
 
@@ -11,7 +12,7 @@ from workflows.prefect_utils.flows_utils import (
 
 
 @task(name="Sync batch of studies metadata from ENA")
-def sync_studies(study_accessions: list[str]):
+def sync_studies(study_accessions: list[str]) -> list[str]:
     """Sync metadata for a batch of studies from ENA.
 
     Each study is synced individually with try/except so that a failure
@@ -39,7 +40,7 @@ def sync_studies_with_ena(
     accessions: list[str] | None = None,
     all_studies: bool = False,
     batch_size: int = 50,
-):
+) -> list[str]:
     """Sync study metadata from ENA for a list of accessions or all studies.
 
     Studies are processed in batches to avoid long-running DB connections.
@@ -47,6 +48,7 @@ def sync_studies_with_ena(
     :param accessions: List of study accessions to sync.
     :param all_studies: If True, sync all studies.
     :param batch_size: Number of studies to process per batch (default 50).
+    :return: List of study accessions that failed to sync.
     """
     logger = get_run_logger()
 
@@ -74,8 +76,16 @@ def sync_studies_with_ena(
         all_failed.extend(failed)
 
     if all_failed:
+        create_table_artifact(
+            key="failed-ena-study-syncs",
+            table=[{"accession": accession} for accession in all_failed],
+            description=f"{len(all_failed)} studies failed to sync from ENA.",
+        )
         logger.warning(
-            f"Failed to sync {len(all_failed)} studies: {', '.join(all_failed)}"
+            f"Failed to sync {len(all_failed)} studies. "
+            "See the 'failed-ena-study-syncs' table artifact for accessions."
         )
     else:
         logger.info("All studies synced successfully")
+
+    return all_failed

--- a/workflows/prefect_deployments/prefect-dev-donco.yaml
+++ b/workflows/prefect_deployments/prefect-dev-donco.yaml
@@ -186,8 +186,18 @@ deployments:
 - name: sync_studies_with_ena
   description: |-
     This flow will sync studies metadata with ENA.
-    :param study_accessions: List of study accessions to sync
+    :param accessions: List of study accessions to sync
   entrypoint: workflows/flows/housekeeping/sync_studies_with_ena.py:sync_studies_with_ena
+  parameters: {}
+  work_pool:
+    name: slurm
+  schedules: []
+
+- name: sync_samples_with_ena
+  description: |-
+    This flow will sync samples metadata with ENA.
+    :param accessions: List of sample accessions to sync
+  entrypoint: workflows/flows/housekeeping/sync_samples_with_ena.py:sync_samples_with_ena
   parameters: {}
   work_pool:
     name: slurm

--- a/workflows/prefect_deployments/prefect-ebi-codon.yaml
+++ b/workflows/prefect_deployments/prefect-ebi-codon.yaml
@@ -259,6 +259,17 @@ deployments:
   work_pool:
     name: slurm
 
+
+- name: sync_samples_with_ena
+  description: |-
+    This flow will sync samples metadata with ENA.
+    :param accessions: List of sample accessions to sync
+  entrypoint: workflows/flows/housekeeping/sync_samples_with_ena.py:sync_samples_with_ena
+  parameters: {}
+  work_pool:
+    name: slurm
+  schedules: []
+
 - name: update_ena_accession_from_json_flow_deployment
   description: |-
     Traverse per-genome JSON files to update Genome.ena_genome_accession from the
@@ -333,7 +344,7 @@ deployments:
 - name: sync_studies_with_ena
   description: |-
     This flow will sync studies metadata with ENA.
-    :param study_accessions: List of study accessions to sync
+    :param accessions: List of study accessions to sync
   entrypoint: workflows/flows/housekeeping/sync_studies_with_ena.py:sync_studies_with_ena
   parameters: {}
   work_pool:

--- a/workflows/tests/test_sync_samples_with_ena.py
+++ b/workflows/tests/test_sync_samples_with_ena.py
@@ -1,6 +1,8 @@
+import json
 from unittest.mock import patch
 
 import pytest
+from prefect.artifacts import Artifact
 
 from ena.models import Sample, Study
 from workflows.flows.housekeeping.sync_samples_with_ena import (
@@ -17,9 +19,10 @@ def test_sync_samples_with_ena_by_accessions(mock_sync, prefect_harness):
     study = Study.objects.create(accession="PRJNA000001", title="Study OK")
     ers_01 = Sample.objects.create(accession="ERS000001", study=study)
     Sample.objects.create(accession="ERS000002", study=study)
+    Sample.objects.create(accession="ERS000003", study=study)
 
     def mock_sync_sample(sample: Sample):
-        if sample.accession == "ERS000002":
+        if sample.accession in {"ERS000002", "ERS000003"}:
             raise RuntimeError("ENA error")
         sample.metadata["sample_title"] = "Updated sample"
         sample.metadata["lat"] = "69.6"
@@ -29,13 +32,41 @@ def test_sync_samples_with_ena_by_accessions(mock_sync, prefect_harness):
     mock_sync.side_effect = mock_sync_sample
 
     failed = sync_samples_with_ena(
-        accessions=["ERS000001", "ERS000002"],
-        batch_size=10,
+        accessions=["ERS000001", "ERS000002", "ERS000003"],
+        batch_size=1,
     )
 
     ers_01.refresh_from_db()
     assert ers_01.metadata["sample_title"] == "Updated sample"
     assert ers_01.metadata["lat"] == "69.6"
 
-    assert failed == ["ERS000002"]
-    assert mock_sync.call_count == 2
+    assert failed == ["ERS000002", "ERS000003"]
+    assert mock_sync.call_count == 3
+
+    failed_syncs_table = Artifact.get("failed-ena-sample-syncs")
+    assert failed_syncs_table.type == "table"
+    assert json.loads(failed_syncs_table.data) == [
+        {"accession": "ERS000002"},
+        {"accession": "ERS000003"},
+    ]
+
+
+@patch(
+    "workflows.flows.housekeeping.sync_samples_with_ena.sync_sample_metadata_from_ena"
+)
+@pytest.mark.django_db
+def test_sync_samples_with_ena_resolves_secondary_accessions(
+    mock_sync, prefect_harness
+):
+    """Test that the flow syncs samples looked up by secondary accession."""
+    study = Study.objects.create(accession="PRJNA000001", title="Study OK")
+    sample = Sample.objects.create(
+        accession="ERS000001",
+        additional_accessions=["SRS000001"],
+        study=study,
+    )
+
+    failed = sync_samples_with_ena(accessions=["SRS000001"], batch_size=1)
+
+    assert failed == []
+    mock_sync.assert_called_once_with(sample)

--- a/workflows/tests/test_sync_samples_with_ena.py
+++ b/workflows/tests/test_sync_samples_with_ena.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+import pytest
+
+from ena.models import Sample, Study
+from workflows.flows.housekeeping.sync_samples_with_ena import (
+    sync_samples_with_ena,
+)
+
+
+@patch(
+    "workflows.flows.housekeeping.sync_samples_with_ena.sync_sample_metadata_from_ena"
+)
+@pytest.mark.django_db
+def test_sync_samples_with_ena_by_accessions(mock_sync, prefect_harness):
+    """Test that the flow syncs specific samples by accession, handling failures."""
+    study = Study.objects.create(accession="PRJNA000001", title="Study OK")
+    ers_01 = Sample.objects.create(accession="ERS000001", study=study)
+    Sample.objects.create(accession="ERS000002", study=study)
+
+    def mock_sync_sample(sample: Sample):
+        if sample.accession == "ERS000002":
+            raise RuntimeError("ENA error")
+        sample.metadata["sample_title"] = "Updated sample"
+        sample.metadata["lat"] = "69.6"
+        sample.save()
+        return
+
+    mock_sync.side_effect = mock_sync_sample
+
+    failed = sync_samples_with_ena(
+        accessions=["ERS000001", "ERS000002"],
+        batch_size=10,
+    )
+
+    ers_01.refresh_from_db()
+    assert ers_01.metadata["sample_title"] == "Updated sample"
+    assert ers_01.metadata["lat"] == "69.6"
+
+    assert failed == ["ERS000002"]
+    assert mock_sync.call_count == 2

--- a/workflows/tests/test_sync_studies_with_ena.py
+++ b/workflows/tests/test_sync_studies_with_ena.py
@@ -1,6 +1,8 @@
+import json
 from unittest.mock import patch
 
 import pytest
+from prefect.artifacts import Artifact
 
 from ena.models import Study
 from workflows.flows.housekeeping.sync_studies_with_ena import (
@@ -27,7 +29,7 @@ def test_sync_studies_with_ena_by_accessions(mock_sync, prefect_harness):
 
     mock_sync.side_effect = mock_sync_study
 
-    sync_studies_with_ena(
+    failed = sync_studies_with_ena(
         accessions=["PRJNA000001", "PRJNA000002"],
         batch_size=10,
     )
@@ -36,4 +38,9 @@ def test_sync_studies_with_ena_by_accessions(mock_sync, prefect_harness):
     assert prj_01.title == "Study OK - and updated!"
     assert prj_01.metadata["description"] == "Study OK - description updated!"
 
+    assert failed == ["PRJNA000002"]
     assert mock_sync.call_count == 2
+
+    failed_syncs_table = Artifact.get("failed-ena-study-syncs")
+    assert failed_syncs_table.type == "table"
+    assert json.loads(failed_syncs_table.data) == [{"accession": "PRJNA000002"}]


### PR DESCRIPTION
This PR: add a flow to sync the samples metadata from ENA

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
