### PR TITLE
cache docker build layers on GHA for faster tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,21 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-      - uses: pre-commit/action@v3.0.1
 
       - name: Build Docker image
-        run: |
-          docker build --target ci -t app:latest .
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: ci
+          tags: app:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: pre-commit/action@v3.0.1
 
       - name: Check for unmigrated code
         run: |


### PR DESCRIPTION
This PR:
* adds caching of docker layers to github actions.

The GHA test suite is getting quite slow – slow enough that it is getting tricky for development.
I looked at a few quick wins. This one was the most obvious to remove a couple of mins from most test runs.

I also looked at:
- don't calculate coverage on every invocation (maybe just PRs). It got a bit fiddly, and probably doesn't make a huge difference.
- removing a bunch of `transaction=True` statements from tests that don't absolutely need them. This should make quite a big speed difference, but it doesn't play super nice with xdist, and I kept having flakey or failing tests so gave up for now.


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
