### PR TITLE
use canonical (pk) for admin pages that can also be accessed by accession

### DIFF
--- a/analyses/admin/base.py
+++ b/analyses/admin/base.py
@@ -128,3 +128,34 @@ def detail_action_error(request, message: str = "Something went wrong"):
     messages.add_message(request, messages.WARNING, message)
     referer = request.META.get("HTTP_REFERER", reverse("admin:index"))
     return redirect(referer)
+
+
+class CanonicalizeAccessionViewMixin:
+    """
+    For models with an accession field, redirect to the canonical PK-based URL if the change view is accessed with an accession.
+    e.g. /admin/analyses/study/MGYS00000002 -> /admin/analyses/study/2
+
+    This allows for related models (e.g. Analysis) to use accession as the FK (e.g. Analysis.study),
+    but for e.g. Study Reports to receive the pk as object_id.
+    """
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        model = self.model
+        if not hasattr(model, "accession"):
+            return super().change_view(request, object_id, form_url, extra_context)
+
+        if not object_id.isdigit():
+            try:
+                obj = model.objects.get(accession=object_id)
+                # Redirect to the canonical PK-based URL
+                return redirect(
+                    reverse(
+                        f"admin:{self.model._meta.app_label}_{self.model._meta.model_name}_change",
+                        args=(obj.pk,),
+                    )
+                )
+            except self.model.DoesNotExist:
+                # Let the default implementation handle 404
+                pass
+
+        return super().change_view(request, object_id, form_url, extra_context)

--- a/analyses/admin/study.py
+++ b/analyses/admin/study.py
@@ -17,6 +17,7 @@ from analyses.admin.base import (
     JSONFieldWidgetOverridesMixin,
     StudyFilter,
     TabularInlinePaginatedWithTabSupport,
+    CanonicalizeAccessionViewMixin,
 )
 from analyses.admin.publication import StudyPublicationInline
 from workflows.models import AssemblyAnalysisPipelineStatus
@@ -113,7 +114,12 @@ class _StudyPublicationInline(StudyPublicationInline):
 
 
 @admin.register(Study)
-class StudyAdmin(ENABrowserLinkMixin, JSONFieldWidgetOverridesMixin, ModelAdmin):
+class StudyAdmin(
+    ENABrowserLinkMixin,
+    JSONFieldWidgetOverridesMixin,
+    CanonicalizeAccessionViewMixin,
+    ModelAdmin,
+):
     inlines = [
         StudyRunsInline,
         StudyAssembliesInline,


### PR DESCRIPTION
This PR:
* makes Study admin page redirect to URL with pk in (instead of accession) when accessed by the latter
* this fixes a bug where navigating to Study change page from a related item that references the Study *by accession* in its fk, led to broken Study Reports sice unfold assumed the object_id will be the pk


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
