### PR TITLE
Legacy data importer bugfixes

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -192,6 +192,9 @@ fileignoreconfig:
 - filename: workflows/data_io_utils/schemas/assembly.py
   checksum: 12b45869a636431bb6e1bfe193f02f301a6b484a0c4503bc793f5450c36c932a
 
+- filename: workflows/flows/legacy/flows/import_legacy_analyses.py
+  allowed_patterns: [key="failed]
+
 - filename: workflows/models.py
   checksum: 487ca9d7edb707de28311b4154ce86a9b10269d29f2951f010db5c17af88d9ae
 

--- a/workflows/data_io_utils/legacy_emg_dbs.py
+++ b/workflows/data_io_utils/legacy_emg_dbs.py
@@ -62,6 +62,10 @@ class LegacyStudy(LegacyEMGBase):
         back_populates="study"
     )
 
+    study_downloads: Mapped[list["LegacyStudyDownload"]] = relationship(
+        back_populates="study"
+    )
+
     biome_id: Mapped[int] = mapped_column(
         "BIOME_ID", ForeignKey("BIOME_HIERARCHY_TREE.BIOME_ID")
     )
@@ -231,6 +235,47 @@ class LegacyDownloadDescription(LegacyEMGBase):
     id: Mapped[int] = mapped_column("DESCRIPTION_ID", Integer, primary_key=True)
     description: Mapped[str] = mapped_column("DESCRIPTION", String)
     description_label: Mapped[str] = mapped_column("DESCRIPTION_LABEL", String)
+
+
+class LegacyDownloadGroupType(LegacyEMGBase):
+    __tablename__ = "DOWNLOAD_GROUP_TYPE"
+
+    id: Mapped[int] = mapped_column("GROUP_ID", Integer, primary_key=True)
+    group_type: Mapped[str] = mapped_column("DOWNLOAD_GROUP_TYPE", String)
+
+
+class LegacyStudyDownload(LegacyEMGBase):
+    __tablename__ = "STUDY_DOWNLOAD"
+
+    id: Mapped[int] = mapped_column("id", Integer, primary_key=True)
+    real_name: Mapped[str] = mapped_column("REAL_NAME", String)
+    alias: Mapped[str] = mapped_column("ALIAS", String)
+
+    format_id: Mapped[int] = mapped_column("FORMAT_ID", Integer)
+
+    study_id: Mapped[int] = mapped_column("STUDY_ID", ForeignKey("STUDY.STUDY_ID"))
+    study: Mapped["LegacyStudy"] = relationship(
+        "LegacyStudy", back_populates="study_downloads"
+    )
+
+    subdir_id: Mapped[int] = mapped_column(
+        "SUBDIR_ID", ForeignKey("DOWNLOAD_SUBDIR.SUBDIR_ID")
+    )
+    subdir: Mapped["LegacyDownloadSubdir"] = relationship("LegacyDownloadSubdir")
+
+    description_id: Mapped[int] = mapped_column(
+        "DESCRIPTION_ID", ForeignKey("DOWNLOAD_DESCRIPTION_LABEL.DESCRIPTION_ID")
+    )
+    description: Mapped["LegacyDownloadDescription"] = relationship(
+        "LegacyDownloadDescription"
+    )
+
+    group_id: Mapped[int] = mapped_column(
+        "GROUP_ID", ForeignKey("DOWNLOAD_GROUP_TYPE.GROUP_ID")
+    )
+    group_type: Mapped["LegacyDownloadGroupType"] = relationship(
+        "LegacyDownloadGroupType"
+    )
 
 
 class LegacyAnalysisJobDownload(LegacyEMGBase):

--- a/workflows/fixtures/legacy_emg_dbs/conftest.py
+++ b/workflows/fixtures/legacy_emg_dbs/conftest.py
@@ -12,11 +12,13 @@ from workflows.data_io_utils.legacy_emg_dbs import (
     LegacyAnalysisJobDownload,
     LegacyBiome,
     LegacyDownloadDescription,
+    LegacyDownloadGroupType,
     LegacyDownloadSubdir,
     LegacyEMGBase,
     LegacyRun,
     LegacySample,
     LegacyStudy,
+    LegacyStudyDownload,
 )
 
 
@@ -75,7 +77,7 @@ def in_memory_legacy_emg_db():
         run_id=1001,
         study_id=5000,
         pipeline_id=6,  # 6 is v5.0 in legacy EMG DB
-        result_directory="some/dir/in/results",
+        result_directory="2019/06/ERP1/version_5.0/ERZ1/001/ERZ1_FASTA",
         external_run_ids="ERR1000",
         secondary_accession="ERR1000",
         experiment_type_id=3,  # amplicon
@@ -104,6 +106,35 @@ def in_memory_legacy_emg_db():
         group_id=3,  # taxonomic analysis of some sort
     )
     session.add(amplicon_download)
+
+    study_summary_description = LegacyDownloadDescription(
+        id=100,
+        description="Taxonomy abundances LSU",
+        description_label="Taxonomy abundances LSU",
+    )
+    session.add(study_summary_description)
+
+    study_summary_subdir = LegacyDownloadSubdir(
+        id=100, subdir="version_5.0/project-summary"
+    )
+    session.add(study_summary_subdir)
+
+    study_summary_group_type = LegacyDownloadGroupType(
+        id=100, group_type="Taxonomic analysis LSU"
+    )
+    session.add(study_summary_group_type)
+
+    study_download = LegacyStudyDownload(
+        id=1,
+        study_id=5000,
+        real_name="taxonomy_abundances_LSU_v5.0.tsv",
+        alias="taxonomy_abundances_LSU_v5.0.tsv",
+        description_id=100,
+        subdir_id=100,
+        format_id=1,  # TSV
+        group_id=100,
+    )
+    session.add(study_download)
 
     assembly_run = LegacyRun(
         run_id=2001,

--- a/workflows/flows/legacy/flows/import_legacy_analyses.py
+++ b/workflows/flows/legacy/flows/import_legacy_analyses.py
@@ -1,10 +1,28 @@
+import re
 from pathlib import Path
 
+from django.utils.text import slugify
 from prefect import get_run_logger
+from prefect.artifacts import create_table_artifact
 from sqlalchemy import select
 
 import activate_django_first  # noqa
-
+from analyses.base_models.with_downloads_models import (
+    DownloadFile,
+    DownloadFileType,
+    DownloadType,
+)
+from analyses.models import Analysis
+from workflows.data_io_utils.filenames import accession_prefix_separated_dir_path
+from workflows.data_io_utils.legacy_emg_dbs import (
+    LEGACY_DOWNLOAD_TYPE_MAP,
+    LEGACY_FILE_FORMATS_MAP,
+    LegacyStudy,
+    get_taxonomy_from_api_v1_mongo,
+    legacy_emg_db_session,
+    get_functions_from_api_v1_mongo,
+    LEGACY_PIPELINE_ID_MAP,
+)
 from workflows.ena_utils.ena_api_requests import (
     sync_privacy_state_of_ena_study_and_derived_objects,
     sync_study_metadata_from_ena,
@@ -22,23 +40,6 @@ from workflows.flows.legacy.tasks.make_sample_from_legacy_emg_db import (
 from workflows.flows.legacy.tasks.make_study_from_legacy_emg_db import (
     make_study_from_legacy_emg_db,
 )
-
-from analyses.base_models.with_downloads_models import (
-    DownloadFile,
-    DownloadFileType,
-    DownloadType,
-)
-from analyses.models import Analysis
-from workflows.data_io_utils.legacy_emg_dbs import (
-    LEGACY_DOWNLOAD_TYPE_MAP,
-    LEGACY_FILE_FORMATS_MAP,
-    LegacyStudy,
-    get_taxonomy_from_api_v1_mongo,
-    legacy_emg_db_session,
-    get_functions_from_api_v1_mongo,
-    LEGACY_PIPELINE_ID_MAP,
-)
-
 from workflows.prefect_utils.flows_utils import django_db_flow as flow
 
 
@@ -91,12 +92,23 @@ def import_legacy_analyses(mgys: str, fetch_functions: bool = False):
                     f"Analysis {legacy_analysis.job_id} has no linked run or assembly to import"
                 )
 
+            # External results dir for analysis:
+            # Drop the year and month prefix (first two parts), and add the 6-char study prefix.
+            # legacy_analysis.result_directory example: 2019/06/ERP108930/version_4.1/ERZ651/008/ERZ651768_FASTA
+            # study_prefix: ERP108
+            # expected: ERP108/ERP108930/version_4.1/ERZ651/008/ERZ651768_FASTA
+            res_dir_parts = Path(legacy_analysis.result_directory).parts
+            res_dir_stripped = Path(*res_dir_parts[3:])
+            study_prefix = accession_prefix_separated_dir_path(study.first_accession, 6)
+            analysis_external_results_dir = Path(study_prefix) / res_dir_stripped
+
             analysis, created = Analysis.objects.update_or_create(
                 id=legacy_analysis.job_id,
                 defaults={
                     "study": study,
                     "sample": sample,
                     "results_dir": legacy_analysis.result_directory,
+                    "external_results_dir": str(analysis_external_results_dir),
                     "ena_study": study.ena_study,
                     "pipeline_version": LEGACY_PIPELINE_ID_MAP.get(
                         legacy_analysis.pipeline_id
@@ -111,6 +123,10 @@ def import_legacy_analyses(mgys: str, fetch_functions: bool = False):
                 logger.info(f"Created analysis {analysis}")
             else:
                 logger.warning(f"Updated analysis {analysis}")
+
+            # clear existing downloads in case we are retrying
+            analysis.downloads = []
+            analysis.save()
 
             for legacy_download in legacy_analysis.downloads:
                 basename = Path(legacy_download.real_name)
@@ -155,12 +171,61 @@ def import_legacy_analyses(mgys: str, fetch_functions: bool = False):
         sync_privacy_state_of_ena_study_and_derived_objects(study.ena_study)
         sync_study_metadata_from_ena(study.ena_study)
 
+        # clear existing downloads in case we are retrying
+        study.downloads = []
+        study.save()
+        for legacy_study_download in legacy_study.study_downloads:
+            basename = Path(legacy_study_download.real_name)
+
+            if legacy_study_download.subdir:
+                path = Path(legacy_study_download.subdir.subdir) / basename
+            else:
+                path = basename
+
+            # Construct download group: study_summary.v{version}.{group_type_slug}
+            # The subdir contains the version, e.g. "version_5.0/project-summary"
+            version = 0
+            subdir_str = legacy_study_download.subdir.subdir
+            version_match = re.search(r"version_([\d\.]+)", subdir_str)
+            if version_match:
+                version = version_match.group(1)
+            else:
+                logger.warning(
+                    f"No version found in subdir of file {legacy_study_download.id}, using 0"
+                )
+
+            group_type_slug = "unknown"
+            if legacy_study_download.group_type:
+                group_type_slug = slugify(
+                    legacy_study_download.group_type.group_type.lower()
+                )
+
+            download_group = (
+                f"study_summary.v{version}.{group_type_slug.replace('-', '_')}"
+            )
+
+            study.add_download(
+                DownloadFile(
+                    path=str(path),
+                    alias=legacy_study_download.alias,
+                    long_description=legacy_study_download.description.description,
+                    short_description=legacy_study_download.description.description_label,
+                    download_type=LEGACY_DOWNLOAD_TYPE_MAP.get(
+                        legacy_study_download.group_id, DownloadType.OTHER
+                    ),
+                    download_group=download_group,
+                    file_type=LEGACY_FILE_FORMATS_MAP.get(
+                        legacy_study_download.format_id, DownloadFileType.OTHER
+                    ),
+                )
+            )
+
 
 @flow(
     name="Import all legacy analyses",
     flow_run_name="Import legacy analyses from all known studies",
 )
-def import_all_legacy_analyses(fetch_functions: bool = False):
+def import_all_legacy_analyses(fetch_functions: bool = False, mgys_after: int = 0):
     """
     Imports all legacy analyses from all known studies.
 
@@ -171,16 +236,34 @@ def import_all_legacy_analyses(fetch_functions: bool = False):
     :param fetch_functions: Boolean indicating whether to fetch associated
         functions during the import process.
     :type fetch_functions: bool
+    :param mgys_after: Only import study ids greater than this number.
+    :type mgys_after: int
     :return: None
     """
     logger = get_run_logger()
     with legacy_emg_db_session() as session:
-        study_ids_stmt = select(LegacyStudy.id)
+        study_ids_stmt = (
+            select(LegacyStudy.id)
+            .where(LegacyStudy.id > mgys_after)
+            .order_by(LegacyStudy.id.asc())
+        )
         study_ids = session.scalars(study_ids_stmt).all()
 
     logger.info(f"Found {len(study_ids)} legacy studies to import")
+    failed_study_accessions = []
 
     for study_id in study_ids:
         mgys = f"MGYS{study_id:08d}"
         logger.info(f"Importing study {mgys}")
-        import_legacy_analyses(mgys=mgys, fetch_functions=fetch_functions)
+        try:
+            import_legacy_analyses(mgys=mgys, fetch_functions=fetch_functions)
+        except Exception as e:
+            logger.error(f"Failed to import study {mgys}: {e}")
+            failed_study_accessions.append(mgys)
+
+    if failed_study_accessions:
+        create_table_artifact(
+            key="failed-legacy-study-imports",
+            table=[{"accession": accession} for accession in failed_study_accessions],
+            description=f"{len(failed_study_accessions)} studies failed to be imported from legacy EMG DB.",
+        )

--- a/workflows/flows/legacy/tasks/make_study_from_legacy_emg_db.py
+++ b/workflows/flows/legacy/tasks/make_study_from_legacy_emg_db.py
@@ -2,6 +2,7 @@ from prefect import task, get_run_logger
 
 import ena.models
 from analyses.models import Study, Biome
+from workflows.data_io_utils.filenames import accession_prefix_separated_dir_path
 from workflows.data_io_utils.legacy_emg_dbs import LegacyStudy, LegacyBiome
 
 
@@ -33,6 +34,10 @@ def make_study_from_legacy_emg_db(
     if created:
         logger.warning(f"Created new Biome object {biome}")
 
+    external_results_dir = accession_prefix_separated_dir_path(
+        legacy_study.ext_study_id, 6
+    )
+
     mg_study, created = Study.objects.get_or_create(
         id=legacy_study.id,
         defaults={
@@ -40,6 +45,7 @@ def make_study_from_legacy_emg_db(
             "title": legacy_study.study_name,
             "ena_accessions": [legacy_study.ext_study_id, legacy_study.project_id],
             "biome": biome,
+            "external_results_dir": str(external_results_dir),
         },
     )
     if created:

--- a/workflows/prefect_deployments/prefect-dev-donco.yaml
+++ b/workflows/prefect_deployments/prefect-dev-donco.yaml
@@ -224,6 +224,7 @@ deployments:
     It connects to the legacy EMG MySQL and Mongo DBs, but not through Django.
 
     :param fetch_functions: whether to fetch functional annotatins (slow!)
+    :param mgys_after: only import studies with mgys > mgys_after
   entrypoint: workflows/flows/legacy/flows/import_legacy_analyses.py:import_all_legacy_analyses
   work_pool:
     name: slurm

--- a/workflows/prefect_deployments/prefect-ebi-codon.yaml
+++ b/workflows/prefect_deployments/prefect-ebi-codon.yaml
@@ -337,6 +337,7 @@ deployments:
     It connects to the legacy EMG MySQL and Mongo DBs, but not through Django.
 
     :param fetch_functions: whether to fetch functional annotatins (slow!)
+    :param mgys_after: only import studies with mgys > mgys_after
   entrypoint: workflows/flows/legacy/flows/import_legacy_analyses.py:import_all_legacy_analyses
   work_pool:
     name: slurm

--- a/workflows/tests/test_import_legacy_analyses.py
+++ b/workflows/tests/test_import_legacy_analyses.py
@@ -77,6 +77,63 @@ def test_mongo_functional_mock(mock_mongo_client_for_taxonomy_and_protein_functi
 
 @pytest.mark.httpx_mock(should_mock=should_not_mock_httpx_requests_to_prefect_server)
 @pytest.mark.django_db(transaction=True)
+def test_import_all_legacy_analyses_filtering(
+    prefect_harness,
+    in_memory_legacy_emg_db,
+    monkeypatch,
+    mock_mongo_client_for_taxonomy_and_protein_functions,
+    ninja_api_client,
+    ena_any_sample_metadata,
+    httpx_mock,
+):
+    # Add another study to the in-memory DB
+    with in_memory_legacy_emg_db as session:
+        study2 = LegacyStudy(
+            id=5001,
+            centre_name="MARS",
+            study_name="Bugs on mars 2",
+            ext_study_id="ERP2",
+            is_private=False,
+            submission_account_id="Weeble-1",
+            project_id="PRJ2",
+            is_suppressed=False,
+            biome_id=1,
+        )
+        session.add(study2)
+        session.commit()
+
+    # Mock legacy_emg_db_session to use our in_memory_legacy_emg_db
+    import workflows.flows.legacy.flows.import_legacy_analyses as target_module
+
+    monkeypatch.setattr(
+        target_module, "legacy_emg_db_session", lambda: in_memory_legacy_emg_db
+    )
+
+    httpx_mock.add_response(
+        url=re.compile(r".*result=study.*ERP.*"),
+        json=[{"study_accession": "ERP"}],
+        is_reusable=True,
+    )
+
+    # Test filtering with mgys_after=5000
+    # Should only import MGYS00005001
+    importer_flow_run = run_flow_and_capture_logs(
+        import_all_legacy_analyses,
+        mgys_after=5000,
+    )
+
+    assert "Found 1 legacy studies to import" in importer_flow_run.logs
+
+    # Test filtering with mgys_after=0 (default)
+    # Should import both
+    importer_flow_run_all = run_flow_and_capture_logs(
+        import_all_legacy_analyses, mgys_after=0
+    )
+    assert "Found 2 legacy studies to import" in importer_flow_run_all.logs
+
+
+@pytest.mark.httpx_mock(should_mock=should_not_mock_httpx_requests_to_prefect_server)
+@pytest.mark.django_db(transaction=True)
 def test_prefect_import_v5_analyses_flow(
     prefect_harness,
     mock_legacy_emg_db_session,
@@ -112,6 +169,11 @@ def test_prefect_import_v5_analyses_flow(
     assert "ERS1" in imported_analysis.sample.ena_accessions
     assert imported_analysis.study.biome.biome_name == "Martian soil"
     assert ["ERR1000"] == imported_analysis.run.ena_accessions
+    assert imported_analysis.study.external_results_dir == "ERP1/ERP1"
+    assert (
+        imported_analysis.external_results_dir
+        == "ERP1/ERP1/version_5.0/ERZ1/001/ERZ1_FASTA"
+    )
 
     imported_analysis_with_annos: Analysis = Analysis.objects_and_annotations.get(
         accession="MGYA00012345"
@@ -132,7 +194,20 @@ def test_prefect_import_v5_analyses_flow(
         "pr2": None,
     }
 
-    # check download files imported okay
+    # check study download files imported okay
+    study = Study.objects.get(accession="MGYS00005000")
+    assert len(study.downloads) == 1
+    sdl = study.downloads[0]
+    assert (
+        sdl.get("path")
+        == "version_5.0/project-summary/taxonomy_abundances_LSU_v5.0.tsv"
+    )
+    assert sdl.get("alias") == "taxonomy_abundances_LSU_v5.0.tsv"
+    assert sdl.get("download_group") == "study_summary.v5.0.taxonomic_analysis_lsu"
+    # group_id 100 is not in map, so it falls back to DownloadType.OTHER which is "Other"
+    assert sdl.get("download_type") == "Other"
+
+    # check analysis download files imported okay
     assert len(imported_analysis.downloads) == 1
     dl = imported_analysis.downloads[0]
     assert dl.get("path") == "tax/ssu_tax/BUGS_SSU.fasta.mseq_hdf5.biom"


### PR DESCRIPTION
This PR:
* add study download importing to the legacy data importer flow
* adds exception handling for legacy studies that fail to import (e.g. potentially suppressed on ENA)
* adds calculation of the new (transfer services) external_results_dirs for imported legacy studies/analyses


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
