### PR TITLE
Add support to TPA in the import miassembler from fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ task prefect -- deployment run "Download a study read-runs/realistic_example_dep
 * Use Django/postgres JSONFields liberally (they can save a load of complicated JOINs)
 * Apply a schema to JSONFields, using Enums, default dicts, custom pydantic types... see `WithDownloadsModel` for an example
 * Use class mixins and Django abstract models liberally, to add shared/similar functionality to multiple models
+* Prefer accessions over numeric IDs when both are available, especially in logs, task parameters, and workflow code
 * API list endpoints should not perform many/any JOINs. Prefer to have less information on the endpoint than introduce JOINs (it can be separately indexed for search)
 * API detail endpoints may perform JOINs
 * API action endpoints (e.g. `/analyses/MGYA1/taxonomies`) should be used where a very large dataset (`taxonomies`) is to be returned. This means `taxonomies` is not needed (so can be deferred) on the main analysis detail endpoint.

--- a/workflows/flows/import_assemblies_from_filesystem_flow.py
+++ b/workflows/flows/import_assemblies_from_filesystem_flow.py
@@ -135,7 +135,7 @@ def validate_completed_assembly_files(
 @task(name="Import completed assembly")
 def import_completed_assembly(
     reads_mgnify_study_id: int,
-    assembly_submission_mgnify_study_id: int | None,
+    tpa_mgnify_study_accession: str | None,
     run_id: int,
     nextflow_outdir: Path,
     record: dict[str, str],
@@ -148,7 +148,7 @@ def import_completed_assembly(
 
     :param reads_mgnify_study_id: MGnify Study ID for the reads used to produce
         the assembly.
-    :param assembly_submission_mgnify_study_id: MGnify Study ID for the separate
+    :param tpa_mgnify_study_accession: MGnify Study accession for the separate
         assembly submission study when importing TPA assemblies. Pass ``None`` for
         non-TPA imports, where the assembly belongs to the reads study.
     :param run_id: MGnify Run ID for the assembled read run.
@@ -164,8 +164,8 @@ def import_completed_assembly(
     logger = get_run_logger()
     reads_mgnify_study = analyses.models.Study.objects.get(id=reads_mgnify_study_id)
     assembly_submission_mgnify_study = (
-        analyses.models.Study.objects.get(id=assembly_submission_mgnify_study_id)
-        if assembly_submission_mgnify_study_id
+        analyses.models.Study.objects.get(accession=tpa_mgnify_study_accession)
+        if tpa_mgnify_study_accession is not None
         else None
     )
     ena_study = (
@@ -173,6 +173,8 @@ def import_completed_assembly(
         if assembly_submission_mgnify_study
         else reads_mgnify_study.ena_study
     )
+    # TODO: remove the ena_study branch once ENA study handling no longer depends on
+    # legacy assembly-study objects.
 
     run_accession = record["run_accession"]
     run = analyses.models.Run.objects.get(id=run_id)
@@ -459,7 +461,7 @@ def import_assemblies_from_filesystem_flow(
         )
         assembly_id = import_completed_assembly(
             reads_mgnify_study_id,
-            assembly_submission_mgnify_study.id if is_tpa else None,
+            assembly_submission_mgnify_study.accession if is_tpa else None,
             run.id,
             validated_outdir,
             record,

--- a/workflows/flows/import_assemblies_from_filesystem_flow.py
+++ b/workflows/flows/import_assemblies_from_filesystem_flow.py
@@ -14,7 +14,6 @@ from workflows.ena_utils.analysis import ENAAnalysisFields, ENAAnalysisQuery
 from workflows.ena_utils.ena_auth import dcc_auth
 from workflows.ena_utils.ena_api_requests import (
     get_study_readruns_from_ena,
-    get_study_assemblies_from_ena,
 )
 from workflows.ena_utils.requestors import ENAAPIRequest
 from workflows.flows.assemble_study_tasks.miassembler_reports import (
@@ -135,7 +134,8 @@ def validate_completed_assembly_files(
 
 @task(name="Import completed assembly")
 def import_completed_assembly(
-    mgnify_study_id: int,
+    reads_mgnify_study_id: int,
+    assembly_submission_mgnify_study_id: int | None,
     run_id: int,
     nextflow_outdir: Path,
     record: dict[str, str],
@@ -144,9 +144,33 @@ def import_completed_assembly(
 ) -> int:
     """
     Create or update an Assembly from one completed miassembler report row.
+
+    :param reads_mgnify_study_id: MGnify Study ID for the reads used to produce
+        the assembly.
+    :param assembly_submission_mgnify_study_id: MGnify Study ID for the separate
+        assembly submission study when importing TPA assemblies. Pass ``None`` for
+        non-TPA imports, where the assembly belongs to the reads study.
+    :param run_id: MGnify Run ID for the assembled read run.
+    :param nextflow_outdir: miassembler/Nextflow output directory containing the
+        run-level assembly files.
+    :param record: Completed row from ``assembled_runs.csv``.
+    :param study_accession: ENA accession used in the miassembler output path.
+    :param ena_assembly_record: ENA analysis record for the uploaded assembly.
+    :return: The created or updated Assembly ID.
     """
     logger = get_run_logger()
-    mgnify_study = analyses.models.Study.objects.get(id=mgnify_study_id)
+    reads_mgnify_study = analyses.models.Study.objects.get(id=reads_mgnify_study_id)
+    assembly_submission_mgnify_study = (
+        analyses.models.Study.objects.get(id=assembly_submission_mgnify_study_id)
+        if assembly_submission_mgnify_study_id is not None
+        else None
+    )
+    ena_study = (
+        assembly_submission_mgnify_study.ena_study
+        if assembly_submission_mgnify_study
+        else reads_mgnify_study.ena_study
+    )
+
     run_accession = record["run_accession"]
     run = analyses.models.Run.objects.get(id=run_id)
 
@@ -155,22 +179,24 @@ def import_completed_assembly(
             name=record["assembler_name"],
             version=record["assembler_version"],
         )
+        # Create the assembly row for this run.
         assembly, created = (
             analyses.models.Assembly.objects.get_or_create_for_run_and_sample(
                 run=run,
                 sample=run.sample,
-                reads_study=mgnify_study,
-                ena_study=mgnify_study.ena_study,
+                reads_study=reads_mgnify_study,
+                ena_study=ena_study,
                 defaults={
                     "is_private": run.is_private,
                     "webin_submitter": run.webin_submitter,
                 },
             )
         )
-
         assembly.assembler = assembler
-        assembly.reads_study = mgnify_study
-        assembly.ena_study = mgnify_study.ena_study
+        assembly.reads_study = reads_mgnify_study
+        assembly.assembly_study = assembly_submission_mgnify_study
+        # TPA imports follow the submission study.
+        assembly.ena_study = ena_study
         assembly.is_private = run.is_private
         assembly.webin_submitter = run.webin_submitter
         assembly.dir = str(
@@ -329,6 +355,7 @@ def import_assemblies_from_filesystem_flow(
     study_accession: str,
     nextflow_outdir: str | Path,
     fetch_read_runs_from_ena: bool = True,
+    assembled_study_accession: str | None = None,
 ) -> dict[str, list[int] | list[dict[str, str]]]:
     """
     Import miassembler outputs into Assembly records.
@@ -343,11 +370,18 @@ def import_assemblies_from_filesystem_flow(
     refreshed before import, and each completed run must resolve to an ENA assembly
     accession returned by that refresh.
 
-    :param study_accession: ENA study accession for the miassembler outputs.
+    TPA imports provide a separate `assembled_study_accession`; in that case the
+    imported assemblies are linked to that study through `assembly_study`.
+
+    :param study_accession: ENA accession of the reads study to import from.
+    :param assembled_study_accession: ENA accession of the study that receives the
+        assemblies. For non-TPA imports, pass the same accession as
+        ``study_accession``.
     :param nextflow_outdir: miassembler/Nextflow output directory to import from.
     :param fetch_read_runs_from_ena: Whether to refresh read runs from ENA before import.
     """
     logger = get_run_logger()
+
     validated_outdir = validate_assembly_output_dir(nextflow_outdir)
     assembled_runs_report = load_assembled_runs(validated_outdir)
     if assembled_runs_report.empty:
@@ -361,29 +395,38 @@ def import_assemblies_from_filesystem_flow(
     )
 
     qc_failed_runs_report = load_qc_failed_runs(validated_outdir)
-    mgnify_study_id = get_or_create_mgnify_study(study_accession)
+
+    reads_mgnify_study_id = get_or_create_mgnify_study(study_accession)
+    reads_mgnify_study = analyses.models.Study.objects.get(id=reads_mgnify_study_id)
+
+    assembly_submission_mgnify_study = None
+    if assembled_study_accession is not None:
+        assembly_submission_mgnify_study = analyses.models.Study.objects.get(
+            id=get_or_create_mgnify_study(assembled_study_accession)
+        )
+
+    is_tpa = (
+        assembly_submission_mgnify_study is not None
+        and assembly_submission_mgnify_study != reads_mgnify_study
+    )
+
     ena_fetch_limit = len(assembled_runs_report)
 
     if fetch_read_runs_from_ena:
-        mgnify_study = analyses.models.Study.objects.get(id=mgnify_study_id)
         read_runs = get_study_readruns_from_ena(
-            mgnify_study.first_accession,
+            reads_mgnify_study.first_accession,
             limit=ena_fetch_limit,
             raise_on_empty=False,
         )
         logger.info(f"Fetched or refreshed {len(read_runs)} read runs from ENA")
 
-    mgnify_study = analyses.models.Study.objects.get(id=mgnify_study_id)
-    ena_assembly_accessions = get_study_assemblies_from_ena(
-        mgnify_study.ena_study.accession,
-        limit=ena_fetch_limit,
+    study_containing_assemblies = (
+        assembly_submission_mgnify_study if is_tpa else reads_mgnify_study
     )
-    logger.info(
-        f"Fetched or refreshed {len(ena_assembly_accessions)} assemblies from ENA"
-    )
+
     ena_assembly_records = get_study_assembly_records_from_ena(
-        mgnify_study.ena_study.accession,
-        mgnify_study.accession,
+        study_containing_assemblies.ena_study.accession,
+        study_containing_assemblies.accession,
         ena_fetch_limit,
     )
 
@@ -398,7 +441,8 @@ def import_assemblies_from_filesystem_flow(
             ena_assembly_records,
         )
         assembly_id = import_completed_assembly(
-            mgnify_study_id,
+            reads_mgnify_study_id,
+            assembly_submission_mgnify_study.id if is_tpa else None,
             run.id,
             validated_outdir,
             record,

--- a/workflows/flows/import_assemblies_from_filesystem_flow.py
+++ b/workflows/flows/import_assemblies_from_filesystem_flow.py
@@ -165,7 +165,7 @@ def import_completed_assembly(
     reads_mgnify_study = analyses.models.Study.objects.get(id=reads_mgnify_study_id)
     assembly_submission_mgnify_study = (
         analyses.models.Study.objects.get(id=assembly_submission_mgnify_study_id)
-        if assembly_submission_mgnify_study_id is not None
+        if assembly_submission_mgnify_study_id
         else None
     )
     ena_study = (

--- a/workflows/flows/import_assemblies_from_filesystem_flow.py
+++ b/workflows/flows/import_assemblies_from_filesystem_flow.py
@@ -141,6 +141,7 @@ def import_completed_assembly(
     record: dict[str, str],
     study_accession: str,
     ena_assembly_record: dict[str, str],
+    overwrite_existing_assemblies: bool = False,
 ) -> int:
     """
     Create or update an Assembly from one completed miassembler report row.
@@ -156,6 +157,8 @@ def import_completed_assembly(
     :param record: Completed row from ``assembled_runs.csv``.
     :param study_accession: ENA accession used in the miassembler output path.
     :param ena_assembly_record: ENA analysis record for the uploaded assembly.
+    :param overwrite_existing_assemblies: Allow updating an existing assembly row for
+        the same run/sample pair instead of failing.
     :return: The created or updated Assembly ID.
     """
     logger = get_run_logger()
@@ -192,6 +195,12 @@ def import_completed_assembly(
                 },
             )
         )
+        # This bit here to is to prevent overwriting existing assemblies by default.
+        if not created and not overwrite_existing_assemblies:
+            raise ValueError(
+                f"Assembly for run {run_accession} already exists in the database"
+            )
+
         assembly.assembler = assembler
         assembly.reads_study = reads_mgnify_study
         assembly.assembly_study = assembly_submission_mgnify_study
@@ -356,6 +365,7 @@ def import_assemblies_from_filesystem_flow(
     nextflow_outdir: str | Path,
     fetch_read_runs_from_ena: bool = True,
     assembled_study_accession: str | None = None,
+    overwrite_existing_assemblies: bool = False,
 ) -> dict[str, list[int] | list[dict[str, str]]]:
     """
     Import miassembler outputs into Assembly records.
@@ -375,39 +385,46 @@ def import_assemblies_from_filesystem_flow(
 
     :param study_accession: ENA accession of the reads study to import from.
     :param assembled_study_accession: ENA accession of the study that receives the
-        assemblies. For non-TPA imports, pass the same accession as
-        ``study_accession``.
+        assemblies. For non-TPA imports, leave this one empty.
     :param nextflow_outdir: miassembler/Nextflow output directory to import from.
     :param fetch_read_runs_from_ena: Whether to refresh read runs from ENA before import.
+    :param overwrite_existing_assemblies: Allow importing over existing assembly rows
+        for the same run/sample pair instead of failing.
     """
     logger = get_run_logger()
 
-    validated_outdir = validate_assembly_output_dir(nextflow_outdir)
+    validated_outdir: Path = validate_assembly_output_dir(nextflow_outdir)
+
     assembled_runs_report = load_assembled_runs(validated_outdir)
     if assembled_runs_report.empty:
         raise ValueError(
             "There are no assemblies to import, the assembled_runs.csv is empty."
         )
+
+    qc_failed_runs_report = load_qc_failed_runs(validated_outdir)
+
     validate_completed_assembly_files(
         validated_outdir,
         study_accession,
         assembled_runs_report,
     )
 
-    qc_failed_runs_report = load_qc_failed_runs(validated_outdir)
-
     reads_mgnify_study_id = get_or_create_mgnify_study(study_accession)
     reads_mgnify_study = analyses.models.Study.objects.get(id=reads_mgnify_study_id)
 
     assembly_submission_mgnify_study = None
     if assembled_study_accession is not None:
+        assembly_submission_mgnify_id = get_or_create_mgnify_study(
+            assembled_study_accession
+        )
         assembly_submission_mgnify_study = analyses.models.Study.objects.get(
-            id=get_or_create_mgnify_study(assembled_study_accession)
+            id=assembly_submission_mgnify_id
         )
 
     is_tpa = (
         assembly_submission_mgnify_study is not None
-        and assembly_submission_mgnify_study != reads_mgnify_study
+        and assembly_submission_mgnify_study
+        != reads_mgnify_study  # in case someone provides the same accession here
     )
 
     ena_fetch_limit = len(assembled_runs_report)
@@ -448,6 +465,7 @@ def import_assemblies_from_filesystem_flow(
             record,
             study_accession,
             ena_assembly_record,
+            overwrite_existing_assemblies=overwrite_existing_assemblies,
         )
         imported_assembly_ids.append(assembly_id)
         imported_assemblies.append(

--- a/workflows/tests/test_import_assemblies_from_filesystem_flow.py
+++ b/workflows/tests/test_import_assemblies_from_filesystem_flow.py
@@ -444,12 +444,44 @@ def test_import_assemblies_from_filesystem_clears_blocked_on_retry(
         output_dir,
         raw_reads_mgnify_study.ena_study.accession,
         assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
+        overwrite_existing_assemblies=True,
     )
 
     assert second_summary["imported"] == first_summary["imported"]
     assembly.refresh_from_db()
     assert assembly.status[assembly.AssemblyStates.ASSEMBLY_UPLOADED]
     assert not assembly.status[assembly.AssemblyStates.ASSEMBLY_BLOCKED]
+
+
+@pytest.mark.django_db
+def test_import_assemblies_from_filesystem_rejects_existing_assembly_by_default(
+    prefect_harness,
+    raw_reads_mgnify_study,
+    raw_read_run,
+    assemblers,
+    tmp_path,
+):
+    output_dir = make_miassembler_output(
+        tmp_path / "miassembler",
+        raw_reads_mgnify_study.ena_study.accession,
+        [("SRR6180434", "metaspades", "3.15.5")],
+    )
+
+    run_import_flow(
+        output_dir,
+        raw_reads_mgnify_study.ena_study.accession,
+        assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Assembly for run SRR6180434 already exists in the database",
+    ):
+        run_import_flow(
+            output_dir,
+            raw_reads_mgnify_study.ena_study.accession,
+            assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
+        )
 
 
 @pytest.mark.django_db

--- a/workflows/tests/test_import_assemblies_from_filesystem_flow.py
+++ b/workflows/tests/test_import_assemblies_from_filesystem_flow.py
@@ -74,6 +74,7 @@ def run_import_flow(
     output_dir: Path,
     study_accession: str,
     ena_assembly_accessions: dict[str, str] | None = None,
+    assembled_study_accession: str | None = None,
     **kwargs,
 ) -> dict[str, list[int] | list[dict[str, str]]]:
     """Invoke the filesystem import flow with the shared test defaults."""
@@ -86,33 +87,6 @@ def run_import_flow(
             )
             if line
         }
-
-    def fetch_ena_assemblies(accession: str, limit: int) -> list[str]:
-        mgnify_study = analyses.models.Study.objects.get(ena_study__accession=accession)
-        accessions = []
-        for run_accession, assembly_accession in ena_assembly_accessions.items():
-            run = analyses.models.Run.objects.get(
-                ena_accessions__contains=[run_accession]
-            )
-            assembly, _ = (
-                analyses.models.Assembly.objects.get_or_create_for_run_and_sample(
-                    run=run,
-                    sample=run.sample,
-                    reads_study=mgnify_study,
-                    ena_study=mgnify_study.ena_study,
-                    defaults={
-                        "is_private": run.is_private,
-                        "webin_submitter": run.webin_submitter,
-                    },
-                )
-            )
-            assembly.ena_accessions = [assembly_accession]
-            assembly.metadata["generated_ftp"] = (
-                f"ftp.sra.ebi.ac.uk/vol1/sequence/{assembly_accession}/contigs.fa.gz"
-            )
-            assembly.save()
-            accessions.append(assembly_accession)
-        return accessions
 
     def fetch_ena_assembly_records(
         study_accession: str,
@@ -132,22 +106,16 @@ def run_import_flow(
             for run_accession, assembly_accession in ena_assembly_accessions.items()
         ]
 
-    with (
-        patch(
-            "workflows.flows.import_assemblies_from_filesystem_flow."
-            "get_study_assemblies_from_ena",
-            side_effect=fetch_ena_assemblies,
-        ),
-        patch(
-            "workflows.flows.import_assemblies_from_filesystem_flow."
-            "get_study_assembly_records_from_ena",
-            side_effect=fetch_ena_assembly_records,
-        ),
+    with patch(
+        "workflows.flows.import_assemblies_from_filesystem_flow."
+        "get_study_assembly_records_from_ena",
+        side_effect=fetch_ena_assembly_records,
     ):
         return import_assemblies_from_filesystem_flow(
             study_accession=study_accession,
             nextflow_outdir=output_dir,
             fetch_read_runs_from_ena=False,
+            assembled_study_accession=assembled_study_accession,
             **kwargs,
         )
 
@@ -166,7 +134,11 @@ def test_import_assemblies_from_filesystem_rejects_empty_assembled_runs_report(
         ValueError,
         match="There are no assemblies to import, the assembled_runs.csv is empty.",
     ):
-        run_import_flow(output_dir, raw_reads_mgnify_study.ena_study.accession)
+        run_import_flow(
+            output_dir,
+            raw_reads_mgnify_study.ena_study.accession,
+            assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
+        )
 
 
 @pytest.mark.django_db
@@ -184,7 +156,11 @@ def test_import_assemblies_from_filesystem_treats_empty_qc_failed_report_as_none
     )
     (output_dir / "qc_failed_runs.csv").write_text("")
 
-    summary = run_import_flow(output_dir, raw_reads_mgnify_study.ena_study.accession)
+    summary = run_import_flow(
+        output_dir,
+        raw_reads_mgnify_study.ena_study.accession,
+        assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
+    )
 
     assert summary["qc_failed"] == []
     assert len(summary["imported"]) == 1
@@ -220,7 +196,9 @@ def test_import_assemblies_from_filesystem_imports_completed_and_reports_qc_fail
         side_effect=capture_table_artifact,
     ):
         summary = run_import_flow(
-            output_dir, raw_reads_mgnify_study.ena_study.accession
+            output_dir,
+            raw_reads_mgnify_study.ena_study.accession,
+            assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
         )
 
     assert len(summary["imported"]) == 1
@@ -275,7 +253,7 @@ def test_import_assemblies_from_filesystem_imports_completed_and_reports_qc_fail
 
 
 @pytest.mark.django_db
-def test_import_assemblies_from_filesystem_preserves_input_study_accession(
+def test_import_assemblies_from_filesystem_leaves_assembly_study_unset_for_non_tpa(
     prefect_harness,
     raw_read_ena_study,
     raw_reads_mgnify_study,
@@ -294,11 +272,81 @@ def test_import_assemblies_from_filesystem_preserves_input_study_accession(
         [("SRR6180434", "metaspades", "3.15.5")],
     )
 
-    summary = run_import_flow(output_dir, alias_accession)
+    summary = run_import_flow(
+        output_dir,
+        alias_accession,
+        assembled_study_accession=alias_accession,
+    )
 
     imported = analyses.models.Assembly.objects.get(id=summary["imported"][0])
+    assert imported.reads_study == raw_reads_mgnify_study
+    assert imported.assembly_study is None
     assert imported.dir == str(
         miassembler_run_output_dir(output_dir, alias_accession, "SRR6180434")
+    )
+    assert imported.status[imported.AssemblyStates.ASSEMBLY_UPLOADED]
+
+
+@pytest.mark.django_db
+def test_import_assemblies_from_filesystem_defaults_to_non_tpa_when_assembled_study_is_omitted(
+    prefect_harness,
+    raw_reads_mgnify_study,
+    raw_read_run,
+    assemblers,
+    tmp_path,
+):
+    output_dir = make_miassembler_output(
+        tmp_path / "miassembler",
+        raw_reads_mgnify_study.ena_study.accession,
+        [("SRR6180434", "metaspades", "3.15.5")],
+    )
+
+    summary = run_import_flow(
+        output_dir,
+        raw_reads_mgnify_study.ena_study.accession,
+    )
+
+    imported = analyses.models.Assembly.objects.get(id=summary["imported"][0])
+    assert imported.reads_study == raw_reads_mgnify_study
+    assert imported.assembly_study is None
+    assert imported.status[imported.AssemblyStates.ASSEMBLY_UPLOADED]
+
+
+@pytest.mark.django_db
+def test_import_assemblies_from_filesystem_supports_third_party_assembly_study(
+    prefect_harness,
+    raw_reads_mgnify_study,
+    raw_read_run,
+    assemblers,
+    assembly_ena_study,
+    tmp_path,
+):
+    assembly_mgnify_study = analyses.models.Study.objects.get_or_create(
+        ena_study=assembly_ena_study,
+        title=assembly_ena_study.title,
+    )[0]
+    assembly_mgnify_study.inherit_accessions_from_related_ena_object("ena_study")
+
+    reads_accession = raw_reads_mgnify_study.ena_study.accession
+    assembled_accession = assembly_ena_study.accession
+    output_dir = make_miassembler_output(
+        tmp_path / "miassembler",
+        reads_accession,
+        [("SRR6180434", "metaspades", "3.15.5")],
+    )
+
+    summary = run_import_flow(
+        output_dir,
+        reads_accession,
+        assembled_study_accession=assembled_accession,
+    )
+
+    imported = analyses.models.Assembly.objects.get(id=summary["imported"][0])
+    assert imported.reads_study == raw_reads_mgnify_study
+    assert imported.assembly_study == assembly_mgnify_study
+    assert imported.ena_study == assembly_mgnify_study.ena_study
+    assert imported.dir == str(
+        miassembler_run_output_dir(output_dir, reads_accession, "SRR6180434")
     )
     assert imported.status[imported.AssemblyStates.ASSEMBLY_UPLOADED]
 
@@ -319,32 +367,26 @@ def test_import_assemblies_from_filesystem_requires_existing_run(
         [("SRR6180434", "metaspades", "3.15.5")],
     )
 
-    with (
-        patch(
-            "workflows.flows.import_assemblies_from_filesystem_flow."
-            "get_study_assemblies_from_ena",
-            return_value=["ERZ000001"],
-        ),
-        patch(
-            "workflows.flows.import_assemblies_from_filesystem_flow."
-            "get_study_assembly_records_from_ena",
-            return_value=[
-                {
-                    "run_accession": "SRR6180434",
-                    "analysis_alias": "SRR6180434",
-                    "analysis_accession": "ERZ000001",
-                    "generated_ftp": (
-                        "ftp.sra.ebi.ac.uk/vol1/sequence/ERZ000001/contigs.fa.gz"
-                    ),
-                }
-            ],
-        ),
+    with patch(
+        "workflows.flows.import_assemblies_from_filesystem_flow."
+        "get_study_assembly_records_from_ena",
+        return_value=[
+            {
+                "run_accession": "SRR6180434",
+                "analysis_alias": "SRR6180434",
+                "analysis_accession": "ERZ000001",
+                "generated_ftp": (
+                    "ftp.sra.ebi.ac.uk/vol1/sequence/ERZ000001/contigs.fa.gz"
+                ),
+            }
+        ],
     ):
         with pytest.raises(analyses.models.Run.DoesNotExist):
             import_assemblies_from_filesystem_flow(
                 study_accession=raw_reads_mgnify_study.ena_study.accession,
                 nextflow_outdir=output_dir,
                 fetch_read_runs_from_ena=False,
+                assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
             )
 
 
@@ -360,7 +402,11 @@ def test_import_assemblies_from_filesystem_rejects_invalid_run_accession_in_repo
     (output_dir / "qc_failed_runs.csv").write_text("")
 
     with pytest.raises(pa.errors.SchemaError, match="INVALID"):
-        run_import_flow(output_dir, raw_reads_mgnify_study.ena_study.accession)
+        run_import_flow(
+            output_dir,
+            raw_reads_mgnify_study.ena_study.accession,
+            assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
+        )
 
 
 @pytest.mark.django_db
@@ -387,13 +433,17 @@ def test_import_assemblies_from_filesystem_clears_blocked_on_retry(
     )
 
     first_summary = run_import_flow(
-        output_dir, raw_reads_mgnify_study.ena_study.accession
+        output_dir,
+        raw_reads_mgnify_study.ena_study.accession,
+        assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
     )
     assembly = analyses.models.Assembly.objects.get(id=first_summary["imported"][0])
     assembly.mark_status(assembly.AssemblyStates.ASSEMBLY_BLOCKED)
 
     second_summary = run_import_flow(
-        output_dir, raw_reads_mgnify_study.ena_study.accession
+        output_dir,
+        raw_reads_mgnify_study.ena_study.accession,
+        assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
     )
 
     assert second_summary["imported"] == first_summary["imported"]
@@ -418,7 +468,11 @@ def test_import_assemblies_from_filesystem_fails_without_coverage_report(
     )
 
     with pytest.raises(FileNotFoundError, match="coverage"):
-        run_import_flow(output_dir, raw_reads_mgnify_study.ena_study.accession)
+        run_import_flow(
+            output_dir,
+            raw_reads_mgnify_study.ena_study.accession,
+            assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
+        )
 
     assert not analyses.models.Assembly.objects.filter(
         runs__ena_accessions__contains=["SRR6180434"]
@@ -441,7 +495,11 @@ def test_import_assemblies_from_filesystem_fails_without_contigs(
     )
 
     with pytest.raises(FileNotFoundError, match="contigs"):
-        run_import_flow(output_dir, raw_reads_mgnify_study.ena_study.accession)
+        run_import_flow(
+            output_dir,
+            raw_reads_mgnify_study.ena_study.accession,
+            assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
+        )
 
     assert not analyses.models.Assembly.objects.filter(
         runs__ena_accessions__contains=["SRR6180434"]
@@ -471,6 +529,7 @@ def test_import_assemblies_from_filesystem_requires_assembly_in_ena(
                 output_dir,
                 raw_reads_mgnify_study.ena_study.accession,
                 ena_assembly_accessions={},
+                assembled_study_accession=raw_reads_mgnify_study.ena_study.accession,
             )
 
     mock_import_completed_assembly.assert_not_called()


### PR DESCRIPTION
Add support to TPA in the import miassembler from fs

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
