### PR TITLE
Housekeeping flow -> fix eggnogmapper duplicated headers

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -225,6 +225,9 @@ fileignoreconfig:
 - filename: workflows/flows/housekeeping/sync_studies_with_ena.py
   allowed_patterns: [key]
 
+- filename: workflows/flows/housekeeping/fix_eggnog_tsv_headers.py
+  allowed_patterns: [key]
+
 - filename: workflows/tests/test_flows_utils.py
   checksum: 7044790c62db033597a0c9391751a32f2db1f88d5ba5a953b6c607d97ff7ed6d
 

--- a/workflows/flows/housekeeping/fix_eggnog_tsv_headers.py
+++ b/workflows/flows/housekeeping/fix_eggnog_tsv_headers.py
@@ -34,6 +34,7 @@ class EggnogHeaderFixCandidate(TypedDict, total=False):
     external_path: str
     has_duplicate_header: bool
     backup_path: str
+    synced_to_ftp: bool
 
 
 def _analysis_eggnog_annotation_downloads(analysis: Analysis):
@@ -228,18 +229,22 @@ def repair_eggnog_header_files(
 @task(name="Resync EggNOG results to FTP")
 def resync_eggnog_results_to_ftp(
     candidates: list[EggnogHeaderFixCandidate],
-) -> list[str]:
+) -> list[EggnogHeaderFixCandidate]:
     """Re-sync repaired EggNOG TSVs from NFS to the external tree.
 
     :param candidates: Repaired candidate files to sync.
     """
     logger = get_run_logger()
+    synced_candidates = [dict(candidate) for candidate in candidates]
+    for candidate in synced_candidates:
+        candidate["synced_to_ftp"] = False
 
-    synced_analyses: list[str] = []
     analyses = _eggnog_analyses(
-        sorted({candidate["analysis_accession"] for candidate in candidates})
+        sorted({candidate["analysis_accession"] for candidate in synced_candidates})
     )
-    candidate_paths = {Path(candidate["nfs_path"]) for candidate in candidates}
+    candidate_by_path = {
+        Path(candidate["nfs_path"]): candidate for candidate in synced_candidates
+    }
 
     for analysis in analyses:
         if not analysis.results_dir or not analysis.external_results_dir:
@@ -253,9 +258,12 @@ def resync_eggnog_results_to_ftp(
         source_root = Path(analysis.results_dir)
         target_root = Path(mirror_root) / analysis.external_results_dir
         source_files = [
-            path for path in candidate_paths if path.is_relative_to(source_root)
+            path for path in candidate_by_path if path.is_relative_to(source_root)
         ]
         if not source_files:
+            logger.info(
+                f"No EggNOG source files to sync for {analysis.accession}; skipping"
+            )
             continue
 
         logger.info(f"Re-syncing EggNOG results for {analysis.accession}")
@@ -271,12 +279,17 @@ def resync_eggnog_results_to_ftp(
                 "partition": EMG_CONFIG.slurm.datamover_partition,
             },
         )
-        synced_analyses.append(analysis.accession)
+        for path in source_files:
+            candidate_by_path[path]["synced_to_ftp"] = True
 
-    logger.info(
-        f"Re-synced EggNOG results for {len(synced_analyses)} analyfisis/analyses"
+    synced_count = sum(
+        1 for candidate in synced_candidates if candidate["synced_to_ftp"]
     )
-    return synced_analyses
+    logger.info(
+        f"Re-synced EggNOG results for {synced_count} of {len(synced_candidates)} "
+        "candidate(s)"
+    )
+    return synced_candidates
 
 
 @flow(flow_run_name="Repair EggNOG TSV headers")
@@ -316,5 +329,4 @@ def repair_eggnog_tsv_headers(
         logger.info("No repaired analyses to sync to FTP.")
         return []
 
-    resync_eggnog_results_to_ftp(repaired)
-    return repaired
+    return resync_eggnog_results_to_ftp(repaired)

--- a/workflows/flows/housekeeping/fix_eggnog_tsv_headers.py
+++ b/workflows/flows/housekeeping/fix_eggnog_tsv_headers.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import csv
+import gzip
+import shutil
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TypedDict
+
+from prefect import get_run_logger
+from prefect.artifacts import create_table_artifact
+from prefect.deployments import run_deployment
+
+from activate_django_first import EMG_CONFIG  # noqa: F401
+
+from analyses.models import Analysis
+from workflows.prefect_utils.flows_utils import (
+    django_db_flow as flow,
+    django_db_task as task,
+)
+from workflows.prefect_utils.build_cli_command import cli_command
+
+EGGNOG_FOLDER = "eggnog"
+EGGNOG_ANNOTATIONS_SUFFIX = "_emapper_annotations.tsv.gz"
+EGGNOG_DOWNLOAD_GROUP = f"{Analysis.FUNCTIONAL_ANNOTATION}.eggnog"
+
+
+class EggnogHeaderFixCandidate(TypedDict, total=False):
+    """Shape of a candidate EggNOG file that needs its duplicate header removed."""
+
+    analysis_accession: str
+    download_alias: str
+    nfs_path: str
+    external_path: str
+    has_duplicate_header: bool
+    backup_path: str
+
+
+def _analysis_eggnog_annotation_downloads(analysis: Analysis):
+    """Return EggNOG annotation downloads for one analysis.
+
+    :param analysis: Analysis to inspect.
+    """
+    return [
+        download
+        for download in analysis.downloads_as_objects
+        if str(download.path).endswith(EGGNOG_ANNOTATIONS_SUFFIX)
+    ]
+
+
+def _eggnog_analyses(analysis_accessions: list[str] | None = None):
+    """Return assembly analyses with EggNOG downloads.
+
+    :param analysis_accessions: Optional accession filter.
+    """
+    analyses = (
+        Analysis.objects.filter(
+            assembly__isnull=False,
+            downloads__contains=[{"download_group": EGGNOG_DOWNLOAD_GROUP}],
+        )
+        .select_related("assembly")
+        .order_by("accession")
+    )
+    if analysis_accessions is not None:
+        analyses = analyses.filter(accession__in=analysis_accessions)
+    return analyses
+
+
+def _build_candidate_rows(analysis: Analysis) -> list[EggnogHeaderFixCandidate]:
+    """Build review rows for EggNOG annotation files with repeated headers.
+
+    :param analysis: Analysis to inspect.
+    """
+    if not analysis.results_dir:
+        return []
+
+    results_root = Path(analysis.results_dir)
+
+    downloads = _analysis_eggnog_annotation_downloads(analysis)
+    if not downloads:
+        return []
+
+    if analysis.external_results_dir:
+        external_root = (
+            EMG_CONFIG.slurm.private_results_dir
+            if analysis.is_private
+            else EMG_CONFIG.slurm.ftp_results_dir
+        )
+        external_dir = Path(external_root) / analysis.external_results_dir
+    else:
+        external_dir = None
+
+    rows: list[EggnogHeaderFixCandidate] = []
+    for download in downloads:
+        nfs_path = results_root / str(download.path)
+        if nfs_path.is_file() and has_duplicated_header_lines(nfs_path):
+            if external_dir is not None:
+                external_path = str(external_dir / str(download.path))
+            else:
+                external_path = ""
+
+            rows.append(
+                {
+                    "analysis_accession": analysis.accession,
+                    "download_alias": download.alias,
+                    "nfs_path": str(nfs_path),
+                    "external_path": external_path,
+                    "has_duplicate_header": True,
+                }
+            )
+    return rows
+
+
+def has_duplicated_header_lines(path: Path) -> bool:
+    """Return True when a gzipped EggNOG TSV contains a repeated header row.
+
+    :param path: Gzipped EggNOG TSV path.
+    """
+    with gzip.open(path, "rt", newline="") as handle:
+        reader = csv.reader(handle, delimiter="\t")
+        header = next(reader, None)
+        if header is None:
+            return False
+
+        for row in reader:
+            if row == header:
+                return True
+
+    return False
+
+
+def remove_duplicate_header_lines(path: Path) -> int:
+    """Rewrite a gzipped TSV in place, preserving only the first header line.
+
+    :param path: Gzipped EggNOG TSV path.
+    """
+    with TemporaryDirectory(dir=path.parent) as tmpdir:
+        temp_path = Path(tmpdir) / path.name
+
+        with (
+            gzip.open(path, "rt", newline="") as source_handle,
+            gzip.open(
+                temp_path,
+                "wt",
+                newline="",
+            ) as temp_handle,
+        ):
+            reader = csv.reader(source_handle, delimiter="\t")
+            writer = csv.writer(temp_handle, delimiter="\t", lineterminator="\n")
+            header = next(reader, None)
+            if header is None:
+                return 0
+
+            duplicate_headers = 0
+            writer.writerow(header)
+            for row in reader:
+                if row == header:
+                    duplicate_headers += 1
+                    continue
+                writer.writerow(row)
+
+        if duplicate_headers == 0:
+            return 0
+
+        shutil.copystat(path, temp_path)
+        temp_path.replace(path)
+        return duplicate_headers
+
+
+@task(name="Collect EggNOG header fix candidates")
+def collect_eggnog_header_fix_candidates(
+    analysis_accessions: list[str] | None = None,
+) -> list[EggnogHeaderFixCandidate]:
+    """Collect files with duplicated EggNOG headers and publish a review artifact.
+
+    :param analysis_accessions: Optional accession filter.
+    """
+    logger = get_run_logger()
+    candidates: list[EggnogHeaderFixCandidate] = []
+    for analysis in _eggnog_analyses(analysis_accessions):
+        candidates.extend(_build_candidate_rows(analysis))
+
+    create_table_artifact(
+        key="eggnog-header-fix-candidates",
+        table=candidates,
+        description=(
+            f"EggNOG annotation TSV files with duplicated headers "
+            f"({len(candidates)} file(s) found)"
+        ),
+    )
+
+    logger.info(f"Found {len(candidates)} EggNOG annotation files with bad headers")
+    return candidates
+
+
+@task(name="Repair EggNOG header files")
+def repair_eggnog_header_files(
+    candidates: list[EggnogHeaderFixCandidate],
+) -> list[EggnogHeaderFixCandidate]:
+    """Remove duplicate headers from each candidate file on NFS and back it up.
+
+    :param candidates: Candidate files to repair.
+    """
+    logger = get_run_logger()
+    repaired: list[EggnogHeaderFixCandidate] = []
+
+    for candidate in candidates:
+        path = Path(candidate["nfs_path"])
+        backup_path = path.with_name(f"{path.name}.bak")
+        logger.info(f"Repairing {path}")
+        if not backup_path.exists():
+            shutil.copy2(path, backup_path)
+            logger.info(f"Backed up original file to {backup_path}")
+
+        removed_headers = remove_duplicate_header_lines(path)
+        if removed_headers > 0:
+            repaired_candidate = dict(candidate)
+            repaired_candidate["backup_path"] = str(backup_path)
+            repaired.append(repaired_candidate)
+            logger.info(f"Removed {removed_headers} duplicate header(s) from {path}")
+        else:
+            logger.info(f"No duplicate headers found in {path}; skipping rewrite")
+
+    return repaired
+
+
+@task(name="Resync EggNOG results to FTP")
+def resync_eggnog_results_to_ftp(
+    candidates: list[EggnogHeaderFixCandidate],
+) -> list[str]:
+    """Re-sync repaired EggNOG TSVs from NFS to the external tree.
+
+    :param candidates: Repaired candidate files to sync.
+    """
+    logger = get_run_logger()
+
+    synced_analyses: list[str] = []
+    analyses = _eggnog_analyses(
+        sorted({candidate["analysis_accession"] for candidate in candidates})
+    )
+    candidate_paths = {Path(candidate["nfs_path"]) for candidate in candidates}
+
+    for analysis in analyses:
+        if not analysis.results_dir or not analysis.external_results_dir:
+            continue
+
+        if analysis.is_private:
+            mirror_root = EMG_CONFIG.slurm.private_results_dir
+        else:
+            mirror_root = EMG_CONFIG.slurm.ftp_results_dir
+
+        source_root = Path(analysis.results_dir)
+        target_root = Path(mirror_root) / analysis.external_results_dir
+        source_files = [
+            path for path in candidate_paths if path.is_relative_to(source_root)
+        ]
+        if not source_files:
+            continue
+
+        logger.info(f"Re-syncing EggNOG results for {analysis.accession}")
+
+        run_deployment(
+            name="move-data/move_data_deployment",
+            parameters={
+                "move_command": cli_command(["rsync", "-av"]),
+                "source": [str(path) for path in sorted(source_files)],
+                "target": str(target_root),
+            },
+            job_variables={
+                "partition": EMG_CONFIG.slurm.datamover_partition,
+            },
+        )
+        synced_analyses.append(analysis.accession)
+
+    logger.info(
+        f"Re-synced EggNOG results for {len(synced_analyses)} analyfisis/analyses"
+    )
+    return synced_analyses
+
+
+@flow(flow_run_name="Repair EggNOG TSV headers")
+def repair_eggnog_tsv_headers(
+    analysis_accessions: list[str] | None = None,
+    dry_run: bool = False,
+    sync_to_ftp: bool = False,
+) -> list[EggnogHeaderFixCandidate]:
+    """List, repair, and optionally resync EggNOG TSV files with repeated headers.
+
+    :param analysis_accessions: Optional accession filter.
+    :param dry_run: When True, only list candidates.
+    :param sync_to_ftp: When True, sync repaired files to the mirror.
+    """
+    logger = get_run_logger()
+
+    candidates = collect_eggnog_header_fix_candidates(analysis_accessions)
+
+    if not candidates:
+        logger.info("No EggNOG files need repairing.")
+        return []
+
+    if dry_run:
+        logger.info(
+            f"dry_run=True - listing {len(candidates)} EggNOG file(s) without changes."
+        )
+        return candidates
+
+    logger.info(f"Repairing {len(candidates)} EggNOG file(s) on NFS.")
+    repaired = repair_eggnog_header_files(candidates)
+
+    if not sync_to_ftp:
+        logger.info("sync_to_ftp=False - Flow complete after NFS repair.")
+        return repaired
+
+    if not repaired:
+        logger.info("No repaired analyses to sync to FTP.")
+        return []
+
+    resync_eggnog_results_to_ftp(repaired)
+    return repaired

--- a/workflows/flows/housekeeping/fix_eggnog_tsv_headers.py
+++ b/workflows/flows/housekeeping/fix_eggnog_tsv_headers.py
@@ -176,9 +176,10 @@ def collect_eggnog_header_fix_candidates(
     :param analysis_accessions: Optional accession filter.
     """
     logger = get_run_logger()
-    candidates: list[EggnogHeaderFixCandidate] = []
-    for analysis in _eggnog_analyses(analysis_accessions):
-        candidates.extend(_build_candidate_rows(analysis))
+    candidates: list[EggnogHeaderFixCandidate] = [
+        _build_candidate_rows(analysis)
+        for analysis in _eggnog_analyses(analysis_accessions)
+    ]
 
     create_table_artifact(
         key="eggnog-header-fix-candidates",

--- a/workflows/prefect_deployments/prefect-dev-donco.yaml
+++ b/workflows/prefect_deployments/prefect-dev-donco.yaml
@@ -225,6 +225,21 @@ deployments:
     name: slurm
   schedules: []
 
+- name: repair_eggnog_tsv_headers_deployment
+  description: |-
+    Scan assembly analyses for EggNOG annotation TSV files with duplicated headers.
+    Set dry_run=True to list affected files only.
+    Set sync_to_ftp=True to re-sync repaired EggNOG results to the FTP/private mirror.
+
+    :param analysis_accessions: Optional list of analysis accessions to limit the scan.
+    :param dry_run: If true, only list affected files and make no changes.
+    :param sync_to_ftp: If true, re-sync repaired files to the FTP/private mirror.
+  entrypoint: workflows/flows/housekeeping/fix_eggnog_tsv_headers.py:repair_eggnog_tsv_headers
+  parameters: {}
+  work_pool:
+    name: slurm
+  schedules: []
+
 - name: import_legacy_analyses_deployment
   description: |-
     This flow will iteratively import analyses (made with MGnify V1-V5 pipelines)

--- a/workflows/prefect_deployments/prefect-ebi-codon.yaml
+++ b/workflows/prefect_deployments/prefect-ebi-codon.yaml
@@ -292,6 +292,21 @@ deployments:
     name: slurm
   schedules: []
 
+- name: repair_eggnog_tsv_headers_deployment
+  description: |-
+    Scan assembly analyses for EggNOG annotation TSV files with duplicated headers.
+    Set dry_run=True to list affected files only.
+    Set sync_to_ftp=True to re-sync repaired EggNOG results to the FTP/private mirror.
+
+    :param analysis_accessions: Optional list of analysis accessions to limit the scan.
+    :param dry_run: If true, only list affected files and make no changes.
+    :param sync_to_ftp: If true, re-sync repaired files to the FTP/private mirror.
+  entrypoint: workflows/flows/housekeeping/fix_eggnog_tsv_headers.py:repair_eggnog_tsv_headers
+  parameters: {}
+  work_pool:
+    name: slurm
+  schedules: []
+
 - name: update_ena_accession_from_json_flow_deployment
   description: |-
     Traverse per-genome JSON files to update Genome.ena_genome_accession from the

--- a/workflows/tests/test_fix_eggnog_tsv_headers_flow.py
+++ b/workflows/tests/test_fix_eggnog_tsv_headers_flow.py
@@ -89,10 +89,7 @@ def test_repair_eggnog_tsv_headers_repairs_creates_backup_and_syncs(
         }
     ]
     mock_collect.return_value = candidates
-
-    result = repair_eggnog_tsv_headers(sync_to_ftp=True)
-
-    assert result == [
+    expected = [
         {
             "analysis_accession": "MGYA00000001",
             "download_alias": "sample_emapper_annotations.tsv.gz",
@@ -102,8 +99,14 @@ def test_repair_eggnog_tsv_headers_repairs_creates_backup_and_syncs(
             "backup_path": str(
                 target.with_name("sample_emapper_annotations.tsv.gz.bak")
             ),
+            "synced_to_ftp": True,
         }
     ]
+    mock_resync.return_value = expected
+
+    result = repair_eggnog_tsv_headers(sync_to_ftp=True)
+
+    assert result == expected
     backup_path = target.with_name("sample_emapper_annotations.tsv.gz.bak")
     assert backup_path.exists()
     with gzip.open(target, "rt") as handle:
@@ -118,7 +121,20 @@ def test_repair_eggnog_tsv_headers_repairs_creates_backup_and_syncs(
             "gene1\tortholog1",
         ]
     mock_collect.assert_called_once_with(None)
-    mock_resync.assert_called_once_with(result)
+    mock_resync.assert_called_once_with(
+        [
+            {
+                "analysis_accession": "MGYA00000001",
+                "download_alias": "sample_emapper_annotations.tsv.gz",
+                "nfs_path": str(target),
+                "external_path": "/tmp/ftp/analyses/MGYA00000001/eggnog/sample_emapper_annotations.tsv.gz",
+                "has_duplicate_header": True,
+                "backup_path": str(
+                    target.with_name("sample_emapper_annotations.tsv.gz.bak")
+                ),
+            }
+        ]
+    )
 
 
 @pytest.mark.django_db
@@ -150,7 +166,7 @@ def test_resync_eggnog_results_to_ftp_uses_rsync(
         "has_duplicate_header": True,
     }
 
-    resync_eggnog_results_to_ftp([candidate])
+    result = resync_eggnog_results_to_ftp([candidate])
 
     mock_run_deployment.assert_called_once()
     call_kwargs = mock_run_deployment.call_args.kwargs
@@ -158,3 +174,51 @@ def test_resync_eggnog_results_to_ftp_uses_rsync(
     assert call_kwargs["parameters"]["source"] == [
         str(analysis_root / "eggnog" / "sample_emapper_annotations.tsv.gz")
     ]
+    assert result == [
+        {
+            **candidate,
+            "synced_to_ftp": True,
+        }
+    ]
+
+
+@pytest.mark.django_db
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers._eggnog_analyses")
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers.run_deployment")
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers.get_run_logger")
+def test_resync_eggnog_results_to_ftp_marks_skipped_candidates(
+    mock_logger,
+    mock_run_deployment,
+    mock_analyses,
+    tmp_path,
+    prefect_harness,
+):
+    mock_logger.return_value = Mock()
+    analysis_root = tmp_path / "results"
+    analysis = Mock(
+        accession="MGYA00000001",
+        results_dir=str(analysis_root),
+        external_results_dir="analyses/MGYA00000001",
+        is_private=False,
+    )
+    mock_analyses.return_value = [analysis]
+
+    candidate = {
+        "analysis_accession": "MGYA00000001",
+        "download_alias": "sample_emapper_annotations.tsv.gz",
+        "nfs_path": str(
+            tmp_path / "other" / "eggnog" / "sample_emapper_annotations.tsv.gz"
+        ),
+        "external_path": "/tmp/ftp/analyses/MGYA00000001/eggnog/sample_emapper_annotations.tsv.gz",
+        "has_duplicate_header": True,
+    }
+
+    result = resync_eggnog_results_to_ftp([candidate])
+
+    assert result == [
+        {
+            **candidate,
+            "synced_to_ftp": False,
+        }
+    ]
+    mock_run_deployment.assert_not_called()

--- a/workflows/tests/test_fix_eggnog_tsv_headers_flow.py
+++ b/workflows/tests/test_fix_eggnog_tsv_headers_flow.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from workflows.flows.housekeeping.fix_eggnog_tsv_headers import (
+    repair_eggnog_tsv_headers,
+    resync_eggnog_results_to_ftp,
+)
+
+
+def _write_gzipped_tsv(path: Path, lines: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt") as handle:
+        handle.writelines(lines)
+
+
+@pytest.mark.django_db
+@patch(
+    "workflows.flows.housekeeping.fix_eggnog_tsv_headers.collect_eggnog_header_fix_candidates"
+)
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers.repair_eggnog_header_files")
+@patch(
+    "workflows.flows.housekeeping.fix_eggnog_tsv_headers.resync_eggnog_results_to_ftp"
+)
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers.get_run_logger")
+def test_repair_eggnog_tsv_headers_dry_run_lists_only(
+    mock_logger,
+    mock_resync,
+    mock_repair,
+    mock_collect,
+    prefect_harness,
+):
+    mock_logger.return_value = Mock()
+    candidates = [
+        {
+            "analysis_accession": "MGYA00000001",
+            "download_alias": "sample_emapper_annotations.tsv.gz",
+            "nfs_path": "/tmp/results/eggnog/sample_emapper_annotations.tsv.gz",
+            "external_path": "/tmp/ftp/analyses/MGYA00000001/eggnog/sample_emapper_annotations.tsv.gz",
+            "has_duplicate_header": True,
+        }
+    ]
+    mock_collect.return_value = candidates
+
+    result = repair_eggnog_tsv_headers(dry_run=True)
+
+    assert result == candidates
+    mock_collect.assert_called_once_with(None)
+    mock_repair.assert_not_called()
+    mock_resync.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch(
+    "workflows.flows.housekeeping.fix_eggnog_tsv_headers.collect_eggnog_header_fix_candidates"
+)
+@patch(
+    "workflows.flows.housekeeping.fix_eggnog_tsv_headers.resync_eggnog_results_to_ftp"
+)
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers.get_run_logger")
+def test_repair_eggnog_tsv_headers_repairs_creates_backup_and_syncs(
+    mock_logger,
+    mock_resync,
+    mock_collect,
+    tmp_path,
+    prefect_harness,
+):
+    mock_logger.return_value = Mock()
+    target = tmp_path / "results" / "eggnog" / "sample_emapper_annotations.tsv.gz"
+    _write_gzipped_tsv(
+        target,
+        [
+            "#query\tseed_ortholog\n",
+            "#query\tseed_ortholog\n",
+            "gene1\tortholog1\n",
+        ],
+    )
+    candidates = [
+        {
+            "analysis_accession": "MGYA00000001",
+            "download_alias": "sample_emapper_annotations.tsv.gz",
+            "nfs_path": str(target),
+            "external_path": "/tmp/ftp/analyses/MGYA00000001/eggnog/sample_emapper_annotations.tsv.gz",
+            "has_duplicate_header": True,
+        }
+    ]
+    mock_collect.return_value = candidates
+
+    result = repair_eggnog_tsv_headers(sync_to_ftp=True)
+
+    assert result == [
+        {
+            "analysis_accession": "MGYA00000001",
+            "download_alias": "sample_emapper_annotations.tsv.gz",
+            "nfs_path": str(target),
+            "external_path": "/tmp/ftp/analyses/MGYA00000001/eggnog/sample_emapper_annotations.tsv.gz",
+            "has_duplicate_header": True,
+            "backup_path": str(
+                target.with_name("sample_emapper_annotations.tsv.gz.bak")
+            ),
+        }
+    ]
+    backup_path = target.with_name("sample_emapper_annotations.tsv.gz.bak")
+    assert backup_path.exists()
+    with gzip.open(target, "rt") as handle:
+        assert handle.read().splitlines() == [
+            "#query\tseed_ortholog",
+            "gene1\tortholog1",
+        ]
+    with gzip.open(backup_path, "rt") as handle:
+        assert handle.read().splitlines() == [
+            "#query\tseed_ortholog",
+            "#query\tseed_ortholog",
+            "gene1\tortholog1",
+        ]
+    mock_collect.assert_called_once_with(None)
+    mock_resync.assert_called_once_with(result)
+
+
+@pytest.mark.django_db
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers._eggnog_analyses")
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers.run_deployment")
+@patch("workflows.flows.housekeeping.fix_eggnog_tsv_headers.get_run_logger")
+def test_resync_eggnog_results_to_ftp_uses_rsync(
+    mock_logger,
+    mock_run_deployment,
+    mock_analyses,
+    tmp_path,
+    prefect_harness,
+):
+    mock_logger.return_value = Mock()
+    analysis_root = tmp_path / "results"
+    analysis = Mock(
+        accession="MGYA00000001",
+        results_dir=str(analysis_root),
+        external_results_dir="analyses/MGYA00000001",
+        is_private=False,
+    )
+    mock_analyses.return_value = [analysis]
+
+    candidate = {
+        "analysis_accession": "MGYA00000001",
+        "download_alias": "sample_emapper_annotations.tsv.gz",
+        "nfs_path": str(analysis_root / "eggnog" / "sample_emapper_annotations.tsv.gz"),
+        "external_path": "/tmp/ftp/analyses/MGYA00000001/eggnog/sample_emapper_annotations.tsv.gz",
+        "has_duplicate_header": True,
+    }
+
+    resync_eggnog_results_to_ftp([candidate])
+
+    mock_run_deployment.assert_called_once()
+    call_kwargs = mock_run_deployment.call_args.kwargs
+    assert call_kwargs["parameters"]["move_command"] == "rsync -av"
+    assert call_kwargs["parameters"]["source"] == [
+        str(analysis_root / "eggnog" / "sample_emapper_annotations.tsv.gz")
+    ]


### PR DESCRIPTION
This flow is probably an overkill, but with the robots is very easy to write so instead of a one-of-script I decided to create this mini-monster.

The idea is that it is going to check for duplicated headers in eggnogmapper tsv files, if there any it will correct them. It is quite defensive, it will create a backup copy of the files first and it has a dry_run option and a dont_sync_to_ftp; to prevent messing up production results.

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
