### PR TITLE
Adds additional taxonomy col labels to TaxonomyTSVRow schema

### DIFF
--- a/workflows/data_io_utils/file_rules/mgnify_v6_result_rules.py
+++ b/workflows/data_io_utils/file_rules/mgnify_v6_result_rules.py
@@ -12,7 +12,17 @@ from workflows.data_io_utils.file_rules.rule_factories import (
 class TaxonomyTSVRow(BaseModel):
     otu_id: int = Field(..., alias="OTU ID")
     read_count: Union[float, int] = Field(
-        ..., validation_alias=AliasChoices("SSU", "PR2", "ITSonedb", "UNITE", "LSU")
+        ...,
+        validation_alias=AliasChoices(
+            "SSU",
+            "PR2",
+            "ITSonedb",
+            "ITSoneDB",
+            "UNITE",
+            "LSU",
+            "SILVA-LSU",
+            "SILVA-SSU",
+        ),
     )
     taxonomy: str
     taxid: Optional[int] = Field(None)


### PR DESCRIPTION
This PR:
* adds some extra possible taxonomy labels to the schema for `TaxonomyTSVRow`
  * this is because in Amplicon v6.1 (or perhaps associated changes elsewhere) the label format has changed
  * existing possible labels remain unchanged 

This may have implications to MGnify web client taxonomy source matching, this will need testing later.

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
