### PR TITLE
Helper flow for recovering failed amplicon analysis imports

### DIFF
--- a/workflows/flows/analyse_study_tasks/amplicon/import_completed_amplicon_analyses.py
+++ b/workflows/flows/analyse_study_tasks/amplicon/import_completed_amplicon_analyses.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import List
 
+from activate_django_first import EMG_CONFIG  # noqa
 
 import analyses.models
 from workflows.data_io_utils.mgnify_v6_utils.amplicon import (
@@ -83,3 +84,31 @@ def import_completed_analyses(
                 analysis.AnalysisStates.ANALYSIS_POST_SANITY_CHECK_FAILED,
                 reason=f"Failed during import: {e}",
             )
+
+
+@flow(log_prints=True)
+def recovery_helper_import_completed_analyses_in_study(
+    study_accession: str, analysis_version: analyses.models.Analysis.PipelineVersions
+):
+    """
+    Helper function for importing completed analyses within a specified study and analysis
+    version. Intended for helping with recovery of failed analysis flows.
+    E.g., if you have manually altered some states of analyses, run this flow to import them.
+    Will import ONLY completed analyses that have not already been imported, from this study and pipeline-version combo.
+
+    :param study_accession: Study accession in which completed analyses are looked for
+    :param analysis_version: Pipeline version of analyses to potentially import
+    :return: None
+    """
+    for analysis in (
+        analyses.models.Analysis.objects.filter(
+            study__accession=study_accession, pipeline_version=analysis_version
+        )
+        .filter_by_statuses(
+            [analyses.models.Analysis.AnalysisStates.ANALYSIS_COMPLETED]
+        )
+        .exclude_by_statuses(
+            [analyses.models.Analysis.AnalysisStates.ANALYSIS_ANNOTATIONS_IMPORTED]
+        )
+    ):
+        import_completed_analysis(analysis)

--- a/workflows/prefect_deployments/prefect-dev-donco.yaml
+++ b/workflows/prefect_deployments/prefect-dev-donco.yaml
@@ -265,3 +265,21 @@ deployments:
   entrypoint: workflows/flows/legacy/flows/import_legacy_analyses.py:import_all_legacy_analyses
   work_pool:
     name: slurm
+
+- name: recovery_helper_import_completed_analyses_in_study_deployment
+  version: null
+  tags: []
+  concurrency_limit: null
+  description: |-
+    Helper function for importing completed analyses within a specified study and analysis
+    version. Intended for helping with recovery of failed analysis flows.
+    E.g., if you have manually altered some states of analyses, run this flow to import them.
+    Will import ONLY completed analyses that have not already been imported, from this study and pipeline-version combo.
+
+    :param study_accession: Study accession in which completed analyses are looked for
+    :param analysis_version: Pipeline version of analyses to potentially import
+    :return: None
+  entrypoint: workflows/flows/analyse_study_tasks/amplicon/import_completed_amplicon_analyses.py:recovery_helper_import_completed_analyses_in_study
+  parameters: {}
+  work_pool:
+    name: slurm

--- a/workflows/prefect_deployments/prefect-ebi-codon.yaml
+++ b/workflows/prefect_deployments/prefect-ebi-codon.yaml
@@ -401,3 +401,21 @@ deployments:
   work_pool:
     name: slurm
   schedules: []
+
+- name: recovery_helper_import_completed_analyses_in_study_deployment
+  version: null
+  tags: []
+  concurrency_limit: null
+  description: |-
+    Helper function for importing completed analyses within a specified study and analysis
+    version. Intended for helping with recovery of failed analysis flows.
+    E.g., if you have manually altered some states of analyses, run this flow to import them.
+    Will import ONLY completed analyses that have not already been imported, from this study and pipeline-version combo.
+
+    :param study_accession: Study accession in which completed analyses are looked for
+    :param analysis_version: Pipeline version of analyses to potentially import
+    :return: None
+  entrypoint: workflows/flows/analyse_study_tasks/amplicon/import_completed_amplicon_analyses.py:recovery_helper_import_completed_analyses_in_study
+  parameters: {}
+  work_pool:
+    name: slurm


### PR DESCRIPTION
This PR:
* adds a new wrapper flow + deployment, `recovery_helper_import_completed_analyses_in_study`
  * this is just for importing completed amplicon analyses, as a helper when recovering failed imports.
  * this came up because the post-analysis validator was failing, and just needed a code change. 

This kind of deployed flow helper lets us re-run parts of the analysis, a bit more like ASA flows. I think that is a good pattern to adopt – having deployments for various points in the flows even if we don't typically need those deployments for the happy-path.


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
