### PR TITLE
Add MetaMDBG to analyses/migrations/0030

### DIFF
--- a/analyses/migrations/0030_alter_assembler_name.py
+++ b/analyses/migrations/0030_alter_assembler_name.py
@@ -20,6 +20,7 @@ class Migration(migrations.Migration):
                     ("megahit", "MEGAHIT"),
                     ("spades", "SPAdes"),
                     ("flye", "Flye"),
+                    ("metamdbg", "MetaMDBG"),
                 ],
                 max_length=20,
                 null=True,

--- a/workflows/flows/assemble_study.py
+++ b/workflows/flows/assemble_study.py
@@ -52,6 +52,7 @@ class AssemblerChoices(FutureStrEnum):
     metaspades = "metaspades"
     spades = "spades"
     flye = "flye"
+    metamdbg = "metamdbg"
 
 
 def get_biomes_as_choices():


### PR DESCRIPTION
This PR:
* Will add MetaMDBG as an assembler to use for long reads


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [ ] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
