### PR TITLE
Featrue/genome catalogue downloads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,13 @@ repos:
     rev: 26.3.1
     hooks:
       - id: black
+        language_version: python3.11
         exclude: ^.*\b(migrations)\b.*$
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
       - id: yamllint
+        language_version: python3.11
         args: [--format, parsable, --strict, -c=.yamllint]
   - repo: https://github.com/thoughtworks/talisman
     rev: 'v1.37.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,11 @@ repos:
     rev: 26.3.1
     hooks:
       - id: black
-        language_version: python3.11
         exclude: ^.*\b(migrations)\b.*$
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
       - id: yamllint
-        language_version: python3.11
         args: [--format, parsable, --strict, -c=.yamllint]
   - repo: https://github.com/thoughtworks/talisman
     rev: 'v1.37.0'

--- a/emgapiv2/test_api.py
+++ b/emgapiv2/test_api.py
@@ -288,6 +288,45 @@ def test_api_genome_catalogues(ninja_api_client, genomes, genome_catalogues):
 
 
 @pytest.mark.django_db
+def test_api_genome_catalogue_downloads(ninja_api_client, genome_catalogues):
+    # Arrange: ensure the selected catalogue has a result_directory and one download
+    cat = next(c for c in genome_catalogues if c.catalogue_id == "human-gut-prokaryotes")
+    cat.result_directory = "genomes/catalogues/human-gut-prokaryotes"
+    # Persist a download using the model helper so JSON shape matches production
+    dl = DownloadFile(
+        path="catalogue_meta/summary.tsv",
+        alias="summary.tsv",
+        download_type=DownloadType.OTHER,
+        file_type=DownloadFileType.TSV,
+        short_description="Summary table",
+        long_description="Overall catalogue summary",
+    )
+    # Save result_directory first so URL resolver has it available when endpoint serializes
+    cat.save()
+    cat.add_download(dl)
+
+    # Act: fetch the catalogue detail
+    data = call_endpoint_and_get_data(
+        ninja_api_client, f"/genomes/catalogues/{cat.catalogue_id}", getter=_whole_object
+    )
+
+    # Assert: downloads are exposed with computed URL and without internal fields
+    assert "downloads" in data
+    assert isinstance(data["downloads"], list)
+    assert len(data["downloads"]) >= 1
+
+    entry = next((d for d in data["downloads"] if d.get("alias") == "summary.tsv"), data["downloads"][0])
+    assert "url" in entry
+    assert entry["url"] is not None
+    # URL should be rooted at transfer service and include the result_directory + relative path
+    assert entry["url"].startswith(EMG_CONFIG.service_urls.transfer_services_url_root)
+    assert "genomes/catalogues/human-gut-prokaryotes/catalogue_meta/summary.tsv" in entry["url"]
+    # Internal fields must not leak into the API
+    assert "path" not in entry
+    assert "parent_identifier" not in entry
+
+
+@pytest.mark.django_db
 def test_publication_annotations(ninja_api_client, publication, httpx_mock):
     httpx_mock.add_response(
         url=f"{EMG_CONFIG.europe_pmc.annotations_endpoint}?articleIds=MED:{publication.pubmed_id}&provider={EMG_CONFIG.europe_pmc.annotations_provider}",

--- a/emgapiv2/test_api.py
+++ b/emgapiv2/test_api.py
@@ -290,7 +290,9 @@ def test_api_genome_catalogues(ninja_api_client, genomes, genome_catalogues):
 @pytest.mark.django_db
 def test_api_genome_catalogue_downloads(ninja_api_client, genome_catalogues):
     # Arrange: ensure the selected catalogue has a result_directory and one download
-    cat = next(c for c in genome_catalogues if c.catalogue_id == "human-gut-prokaryotes")
+    cat = next(
+        c for c in genome_catalogues if c.catalogue_id == "human-gut-prokaryotes"
+    )
     cat.result_directory = "genomes/catalogues/human-gut-prokaryotes"
     # Persist a download using the model helper so JSON shape matches production
     dl = DownloadFile(
@@ -307,7 +309,9 @@ def test_api_genome_catalogue_downloads(ninja_api_client, genome_catalogues):
 
     # Act: fetch the catalogue detail
     data = call_endpoint_and_get_data(
-        ninja_api_client, f"/genomes/catalogues/{cat.catalogue_id}", getter=_whole_object
+        ninja_api_client,
+        f"/genomes/catalogues/{cat.catalogue_id}",
+        getter=_whole_object,
     )
 
     # Assert: downloads are exposed with computed URL and without internal fields
@@ -315,12 +319,18 @@ def test_api_genome_catalogue_downloads(ninja_api_client, genome_catalogues):
     assert isinstance(data["downloads"], list)
     assert len(data["downloads"]) >= 1
 
-    entry = next((d for d in data["downloads"] if d.get("alias") == "summary.tsv"), data["downloads"][0])
+    entry = next(
+        (d for d in data["downloads"] if d.get("alias") == "summary.tsv"),
+        data["downloads"][0],
+    )
     assert "url" in entry
     assert entry["url"] is not None
     # URL should be rooted at transfer service and include the result_directory + relative path
     assert entry["url"].startswith(EMG_CONFIG.service_urls.transfer_services_url_root)
-    assert "genomes/catalogues/human-gut-prokaryotes/catalogue_meta/summary.tsv" in entry["url"]
+    assert (
+        "genomes/catalogues/human-gut-prokaryotes/catalogue_meta/summary.tsv"
+        in entry["url"]
+    )
     # Internal fields must not leak into the API
     assert "path" not in entry
     assert "parent_identifier" not in entry

--- a/genomes/models/genome_catalogue.py
+++ b/genomes/models/genome_catalogue.py
@@ -9,6 +9,7 @@ EMG_CONFIG = settings.EMG_CONFIG
 
 
 class GenomeCatalogue(WithDownloadsModel, TimeStampedModel):
+    DOWNLOAD_PARENT_IDENTIFIER_ATTR = "catalogue_id"
     catalogue_id = models.SlugField(
         db_column="catalogue_id", max_length=100, primary_key=True
     )

--- a/genomes/schemas/GenomeCatalogue.py
+++ b/genomes/schemas/GenomeCatalogue.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Dict, Literal, Optional
+from genomes.schemas.MGnifyGenomeCatalogueDownloadFile import MGnifyGenomeCatalogueDownloadFile
 
 from ninja import Field, Schema
 
@@ -31,6 +32,9 @@ class GenomeCatalogueBase(Schema):
         ..., examples=[{"Total proteins": "12,345,678"}]
     )
     biome: Optional["Biome"] = None
+    downloads: list["MGnifyGenomeCatalogueDownloadFile"] = Field(
+        ..., alias="downloads_as_objects"
+    )
 
 
 class GenomeCatalogueDetail(GenomeCatalogueBase): ...

--- a/genomes/schemas/GenomeCatalogue.py
+++ b/genomes/schemas/GenomeCatalogue.py
@@ -1,8 +1,11 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Dict, Literal, Optional
-from genomes.schemas.MGnifyGenomeCatalogueDownloadFile import MGnifyGenomeCatalogueDownloadFile
 
 from ninja import Field, Schema
+
+from genomes.schemas.MGnifyGenomeCatalogueDownloadFile import (
+    MGnifyGenomeCatalogueDownloadFile,
+)
 
 if TYPE_CHECKING:
     from analyses.schemas import Biome

--- a/genomes/schemas/MGnifyGenomeCatalogueDownloadFile.py
+++ b/genomes/schemas/MGnifyGenomeCatalogueDownloadFile.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+from typing import Union
+from urllib.parse import urljoin
+
+from django.conf import settings
+from ninja import Field, Schema
+from typing_extensions import Annotated
+
+from analyses.base_models.with_downloads_models import DownloadFile
+from genomes import models as genome_models
+from workflows.data_io_utils.filenames import trailing_slash_ensured_dir
+
+logger = logging.getLogger(__name__)
+EMG_CONFIG = settings.EMG_CONFIG
+
+
+class MGnifyGenomeCatalogueDownloadFile(Schema, DownloadFile):
+    """
+    Download file representation for GenomeCatalogue objects.
+
+    Resolves a public URL using the catalogue's result_directory, if available.
+    """
+
+    path: Annotated[str, Field(exclude=True)]
+    parent_identifier: Annotated[Union[int, str], Field(exclude=True)]
+
+    url: str | None = None
+
+    @staticmethod
+    def resolve_url(obj: "MGnifyGenomeCatalogueDownloadFile"):
+        try:
+            catalogue = genome_models.GenomeCatalogue.objects.get(
+                catalogue_id=obj.parent_identifier
+            )
+        except genome_models.GenomeCatalogue.DoesNotExist:
+            logger.warning(
+                "No GenomeCatalogue found with catalogue_id %s for download URL resolution",
+                obj.parent_identifier,
+            )
+            return None
+
+        if not catalogue.result_directory:
+            # Without a results directory, we cannot form a URL
+            return None
+
+        return urljoin(
+            EMG_CONFIG.service_urls.transfer_services_url_root,
+            urljoin(trailing_slash_ensured_dir(catalogue.result_directory), obj.path),
+        )

--- a/genomes/schemas/__init__.py
+++ b/genomes/schemas/__init__.py
@@ -2,6 +2,9 @@ from genomes.schemas.GenomeCatalogue import GenomeCatalogueDetail, GenomeCatalog
 from genomes.schemas.GenomeDetail import GenomeDetail
 from genomes.schemas.GenomeList import GenomeList
 from genomes.schemas.GenomeWithAnnotations import GenomeWithAnnotations
+from genomes.schemas.MGnifyGenomeCatalogueDownloadFile import (
+    MGnifyGenomeCatalogueDownloadFile,
+)
 
 __all__ = [
     "GenomeDetail",

--- a/genomes/schemas/__init__.py
+++ b/genomes/schemas/__init__.py
@@ -10,4 +10,5 @@ __all__ = [
     "GenomeCatalogueDetail",
     "GenomeWithAnnotations",
     "MGnifyGenomeDownloadFile",
+    "MGnifyGenomeCatalogueDownloadFile",
 ]


### PR DESCRIPTION
This PR: adds MGnifyGenomeCatalogueDownloadFile to the genomes/catalogues detail endpoint.
It helps in addressing the issue of missing taxonomy tab on the genomes pages in the website, as defined on this ticket:
https://embl.atlassian.net/browse/EMG-9808
*


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
