### PR TITLE
adds api endpoint for samples/{accession}/assemblies

### DIFF
--- a/emgapiv2/api/samples.py
+++ b/emgapiv2/api/samples.py
@@ -8,6 +8,7 @@ from ninja_extra.schemas import NinjaPaginationResponseSchema
 import analyses.models
 from analyses.schemas import (
     AnalysedRun,
+    AssemblyDetail,
     MGnifySample,
     MGnifySampleDetail,
     OrderByFilter,
@@ -18,6 +19,7 @@ from emgapiv2.api.perms import UnauthorisedIsUnfoundController
 from emgapiv2.api.schema_utils import (
     ApiSections,
     BiomeFilter,
+    make_child_link,
     make_links_section,
     make_related_detail_link,
 )
@@ -41,14 +43,28 @@ class SampleController(UnauthorisedIsUnfoundController):
         operation_id="get_mgnify_sample",
         auth=[WebinJWTAuth(), DjangoSuperUserAuth(), NoAuth()],
         openapi_extra=make_links_section(
-            make_related_detail_link(
-                related_detail_operation_id="get_mgnify_study",
-                related_object_name="study",
-                self_object_name="sample",
-                related_id_in_response="accession",
-                from_list_to_detail=True,
-                from_list_at_path="studies/",
-            )
+            {
+                **make_related_detail_link(
+                    related_detail_operation_id="get_mgnify_study",
+                    related_object_name="study",
+                    self_object_name="sample",
+                    related_id_in_response="accession",
+                    from_list_to_detail=True,
+                    from_list_at_path="studies/",
+                ),
+                **make_child_link(
+                    operation_id="list_sample_runs",
+                    child_name="runs",
+                    self_object_name="sample",
+                    description="Runs associated with this sample",
+                ),
+                **make_child_link(
+                    operation_id="list_sample_assemblies",
+                    child_name="assemblies",
+                    self_object_name="sample",
+                    description="Assemblies associated with this sample",
+                ),
+            }
         ),
         permissions=[
             perms.IsPublic | perms.IsWebinOwner | perms.IsAdminUserWithObjectPerms
@@ -113,3 +129,32 @@ class SampleController(UnauthorisedIsUnfoundController):
     def list_sample_runs(self, accession: str):
         sample = analyses.models.Sample.objects.get_by_accession(accession)
         return sample.runs.all()
+
+    @http_get(
+        "/{accession}/assemblies/",
+        response=NinjaPaginationResponseSchema[AssemblyDetail],
+        summary="List assemblies associated with this sample",
+        description=(
+            "Samples may be associated with one or more assemblies. "
+            "Assemblies are collections of contigs generated from sequencing reads."
+        ),
+        operation_id="list_sample_assemblies",
+        tags=[ApiSections.SAMPLES, ApiSections.ASSEMBLIES],
+        openapi_extra=make_links_section(
+            make_related_detail_link(
+                related_detail_operation_id="get_assembly",
+                self_object_name="sample",
+                related_object_name="assembly",
+                related_id_in_response="accession",
+                from_list_to_detail=True,
+            )
+        ),
+        auth=[WebinJWTAuth(), DjangoSuperUserAuth(), NoAuth()],
+        permissions=[
+            perms.IsPublic | perms.IsWebinOwner | perms.IsAdminUserWithObjectPerms
+        ],
+    )
+    @paginate()
+    def list_sample_assemblies(self, accession: str):
+        sample = analyses.models.Sample.objects.get_by_accession(accession)
+        return sample.assemblies.all()

--- a/emgapiv2/test_api.py
+++ b/emgapiv2/test_api.py
@@ -619,6 +619,29 @@ def test_list_sample_runs(ninja_api_client, raw_reads_mgnify_sample, raw_read_ru
 
 
 @pytest.mark.django_db
+def test_list_sample_assemblies(
+    ninja_api_client, raw_reads_mgnify_sample, mgnify_assemblies_with_ena
+):
+    sample: Sample = raw_reads_mgnify_sample[0]
+
+    # Check that sample actually has assemblies in the fixture
+    assert sample.assemblies.count() > 0, "Sample should have assemblies in fixtures"
+
+    items: list = call_endpoint_and_get_data(
+        ninja_api_client,
+        f"/samples/{sample.ena_accessions[0]}/assemblies/",
+        count=sample.assemblies.count(),
+    )
+
+    for assembly in items:
+        assert assembly["accession"] in [
+            a.first_accession for a in sample.assemblies.all()
+        ]
+        assert "sample_accession" in assembly
+        assert assembly["sample_accession"] == sample.ena_sample.accession
+
+
+@pytest.mark.django_db
 def test_runs_assemblies_list(
     ninja_api_client, raw_read_run, mgnify_assemblies_with_ena
 ):


### PR DESCRIPTION
This PR:
* adds new relationship endpoint at samples/{accession}/assemblies
* extends api test coverage for it


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
