### PR TITLE
Fixed issue causing malformed genome catalogue download file links

### DIFF
--- a/genomes/schemas/MGnifyGenomeCatalogueDownloadFile.py
+++ b/genomes/schemas/MGnifyGenomeCatalogueDownloadFile.py
@@ -2,18 +2,15 @@ from __future__ import annotations
 
 import logging
 from typing import Union
-from urllib.parse import urljoin
 
-from django.conf import settings
 from ninja import Field, Schema
 from typing_extensions import Annotated
 
 from analyses.base_models.with_downloads_models import DownloadFile
 from genomes import models as genome_models
-from workflows.data_io_utils.filenames import trailing_slash_ensured_dir
+from genomes.schemas.url_utils import build_transfer_service_public_url
 
 logger = logging.getLogger(__name__)
-EMG_CONFIG = settings.EMG_CONFIG
 
 
 class MGnifyGenomeCatalogueDownloadFile(Schema, DownloadFile):
@@ -45,7 +42,4 @@ class MGnifyGenomeCatalogueDownloadFile(Schema, DownloadFile):
             # Without a results directory, we cannot form a URL
             return None
 
-        return urljoin(
-            EMG_CONFIG.service_urls.transfer_services_url_root,
-            urljoin(trailing_slash_ensured_dir(catalogue.result_directory), obj.path),
-        )
+        return build_transfer_service_public_url(catalogue.result_directory, obj.path)

--- a/genomes/schemas/MGnifyGenomeCatalogueDownloadFile.py
+++ b/genomes/schemas/MGnifyGenomeCatalogueDownloadFile.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated
 
 from analyses.base_models.with_downloads_models import DownloadFile
 from genomes import models as genome_models
-from genomes.schemas.url_utils import build_transfer_service_public_url
+from genomes.schemas.url_utils import build_public_url
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +40,9 @@ class MGnifyGenomeCatalogueDownloadFile(Schema, DownloadFile):
 
         if not catalogue.result_directory:
             # Without a results directory, we cannot form a URL
+            logger.warning(
+                "Catalogue result directory not found for catalogue id %s for download URL resolution",
+            )
             return None
 
-        return build_transfer_service_public_url(catalogue.result_directory, obj.path)
+        return build_public_url(catalogue.result_directory, obj.path)

--- a/genomes/schemas/MGnifyGenomeDownloadFile.py
+++ b/genomes/schemas/MGnifyGenomeDownloadFile.py
@@ -2,18 +2,15 @@ from __future__ import annotations
 
 import logging
 from typing import Union
-from urllib.parse import urljoin
 
-from django.conf import settings
 from ninja import Field, Schema
 from typing_extensions import Annotated
 
 from analyses.base_models.with_downloads_models import DownloadFile
 from genomes import models as genome_models
-from workflows.data_io_utils.filenames import trailing_slash_ensured_dir
+from genomes.schemas.url_utils import build_transfer_service_public_url
 
 logger = logging.getLogger(__name__)
-EMG_CONFIG = settings.EMG_CONFIG
 
 
 class MGnifyGenomeDownloadFile(Schema, DownloadFile):
@@ -35,8 +32,4 @@ class MGnifyGenomeDownloadFile(Schema, DownloadFile):
         if not genome.result_directory:
             # Without a results directory, we cannot form a URL
             return None
-
-        return urljoin(
-            EMG_CONFIG.service_urls.transfer_services_url_root,
-            urljoin(trailing_slash_ensured_dir(genome.result_directory), obj.path),
-        )
+        return build_transfer_service_public_url(genome.result_directory, obj.path)

--- a/genomes/schemas/MGnifyGenomeDownloadFile.py
+++ b/genomes/schemas/MGnifyGenomeDownloadFile.py
@@ -8,7 +8,7 @@ from typing_extensions import Annotated
 
 from analyses.base_models.with_downloads_models import DownloadFile
 from genomes import models as genome_models
-from genomes.schemas.url_utils import build_transfer_service_public_url
+from genomes.schemas.url_utils import build_public_url
 
 logger = logging.getLogger(__name__)
 
@@ -32,4 +32,4 @@ class MGnifyGenomeDownloadFile(Schema, DownloadFile):
         if not genome.result_directory:
             # Without a results directory, we cannot form a URL
             return None
-        return build_transfer_service_public_url(genome.result_directory, obj.path)
+        return build_public_url(genome.result_directory, obj.path)

--- a/genomes/schemas/url_utils.py
+++ b/genomes/schemas/url_utils.py
@@ -8,21 +8,22 @@ from django.conf import settings
 from workflows.data_io_utils.filenames import trailing_slash_ensured_dir
 
 
-def build_transfer_service_public_url(
+def build_public_url(
     result_directory: str | Path | None, file_path: str | Path | None
 ) -> str | None:
     """
     Build a public download URL for a file that lives under a results directory
-    exposed by the Transfer Service.
+    exposed by in EBI FTP server.
     - Ensures the joined path is relative (no leading slash) so the base path is preserved.
     """
-    transfer_service_root_url = (
-        settings.EMG_CONFIG.service_urls.transfer_services_url_root
-    )
+
     # Build a relative path under the result directory ensuring no leading slash
     relative_results_path = (
         f"{trailing_slash_ensured_dir(result_directory).lstrip('/')}"
         f"{str(file_path).lstrip('/')}"
     )
 
-    return urljoin(transfer_service_root_url, relative_results_path)
+    return urljoin(
+        settings.EMG_CONFIG.service_urls.transfer_services_url_root,
+        relative_results_path,
+    )

--- a/genomes/schemas/url_utils.py
+++ b/genomes/schemas/url_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urljoin
+
+from django.conf import settings
+
+from workflows.data_io_utils.filenames import trailing_slash_ensured_dir
+
+
+def build_transfer_service_public_url(
+    result_directory: str | Path | None, file_path: str | Path | None
+) -> str | None:
+    """
+    Build a public download URL for a file that lives under a results directory
+    exposed by the Transfer Service.
+    - Ensures the joined path is relative (no leading slash) so the base path is preserved.
+    """
+    transfer_service_root_url = (
+        settings.EMG_CONFIG.service_urls.transfer_services_url_root
+    )
+    # Build a relative path under the result directory ensuring no leading slash
+    relative_results_path = (
+        f"{trailing_slash_ensured_dir(result_directory).lstrip('/')}"
+        f"{str(file_path).lstrip('/')}"
+    )
+
+    return urljoin(transfer_service_root_url, relative_results_path)


### PR DESCRIPTION
This PR:
Ftp links on Genome catalogues were being malformed due to issues with urljoin() in the resolve_url methhod of Download file schemas.
When a relative path has a preceding slash, url join treats it as an absolute path and this affects how the download links get built. 
This issue was resolved by ensuring that values coming from genome_catalogue.results_dir have no preceding slashes. 

This PR also refactors the resolve_url method, by introducing a new helper: https://github.com/EBI-Metagenomics/emgapi-v2/blob/c25c6f2d4941fead5c68c7bbcf221d00d3a97014/genomes/schemas/url_utils.py

the resolve_url methods of both MGnifyGenomeDownloadFile and MGnifyGenomeCatalogueDownloadFile both make use of that to reduce code repetition
*


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
