### PR TITLE
Install importlib_metadata - remove when prefect is upgraded

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ fastapi==0.123.6
 prefect-shell==0.3.1
 prefect-slack==0.3.1
 prefect-slurm==0.1.5
+importlib-metadata==8.7.1
 
 # Pydantic
 pydantic<2.12.0  # TODO upgrade once https://github.com/eadwinCode/django-ninja-jwt/pull/151 is released


### PR DESCRIPTION
This is related to https://github.com/PrefectHQ/prefect/issues/22011

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [ ] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
