### PR TITLE
removed invalid rna_5.8s data from marine eukaryotes genome import

### DIFF
--- a/genomes/models/genome.py
+++ b/genomes/models/genome.py
@@ -153,6 +153,8 @@ class Genome(WithDownloadsModel, TimeStampedModel):
         genome_data.pop("genome_accession", None)
         genome_data.pop("pangenome", None)
         genome_data.pop("study_accession", None)
+        if "rna_5.8s" in genome_data:
+            genome_data.pop("rna_5.8s", None)
 
         return genome_data
 

--- a/workflows/flows/import_genomes_flow.py
+++ b/workflows/flows/import_genomes_flow.py
@@ -118,6 +118,7 @@ def process_genome_dir(catalogue, genome_dir):
 
     genome_data = Genome.clean_data(genome_data)
     genome_data = Genome.clean_data(genome_data)
+    logger.info(f"UPDATED Writing genome data: {genome_data}")
 
     genome, _ = Genome.objects.update_or_create(
         accession=accession, defaults=genome_data


### PR DESCRIPTION
This PR:
Seeks to address issues that caused marine eukaryotes import to fail. 
This particular fix addresses the presence of an invalid value in the input data.

*


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [ ] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
