### PR TITLE
Adjusts genome import flow to include genome stats columns

### DIFF
--- a/genomes/models/genome.py
+++ b/genomes/models/genome.py
@@ -146,13 +146,31 @@ class Genome(WithDownloadsModel, TimeStampedModel):
     def clean_data(cls, genome_data):
         """
         Clean genome data by removing unnecessary fields and ensuring required fields are present.
+        - Extract selected nested fields from exporter structures (e.g. pangenome) into model fields.
+        - Drop keys that do not belong to the model (basic known drops retained for safety).
         """
+        # Remove fields that are not stored as-is
         genome_data.pop("gold_biome", None)
+        genome_data.pop("genome_accession", None)
+        genome_data.pop("study_accession", None)
+
+        # Map nested pangenome fields if present
+        pangenome = genome_data.get("pangenome")
+        if isinstance(pangenome, dict):
+            # Store total number of genomes in the pangenome, if provided
+            if (
+                "num_genomes_total" in pangenome
+                and "num_genomes_total" not in genome_data
+            ):
+                genome_data["num_genomes_total"] = pangenome.get("num_genomes_total")
+        # Remove the nested pangenome blob from defaults passed to ORM
+        genome_data.pop("pangenome", None)
+
+        # Normalise annotations container
         if "annotations" not in genome_data:
             genome_data["annotations"] = cls.default_annotations()
-        genome_data.pop("genome_accession", None)
-        genome_data.pop("pangenome", None)
-        genome_data.pop("study_accession", None)
+
+        # Normalise rRNA key variation that sometimes appears in exporter JSON
         if "rna_5.8s" in genome_data:
             genome_data.pop("rna_5.8s", None)
 

--- a/genomes/schemas/GenomeDetail.py
+++ b/genomes/schemas/GenomeDetail.py
@@ -8,6 +8,21 @@ from genomes.schemas.MGnifyGenomeDownloadFile import MGnifyGenomeDownloadFile
 
 
 class GenomeDetail(GenomeBase):
+    # Additional fields to expose on the genome detail endpoint
+    rna_5s: Optional[float] = None
+    rna_5_8s: Optional[float] = None
+    rna_16s: Optional[float] = None
+    rna_18s: Optional[float] = None
+    rna_23s: Optional[float] = None
+    rna_28s: Optional[float] = None
+    trnas: Optional[float] = None
+    nc_rnas: Optional[float] = None
+    eggnog_coverage: Optional[float] = None
+    ipr_coverage: Optional[float] = None
+
+    num_genomes_total: Optional[int] = None
+    num_proteins: Optional[int] = None
+
     downloads: list["MGnifyGenomeDownloadFile"] = Field(
         ..., alias="downloads_as_objects"
     )


### PR DESCRIPTION
This PR:
*
Adjusts genome import flow to include genome stats columns. Also exposes new columns to Genome detail endpoint.

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
