### PR TITLE
Normalize exporter key rna_5.8s to rna_5_8s in Genome.clean_data

### DIFF
--- a/genomes/models/genome.py
+++ b/genomes/models/genome.py
@@ -173,6 +173,7 @@ class Genome(WithDownloadsModel, TimeStampedModel):
 
         # Normalise rRNA key variation that sometimes appears in exporter JSON
         if "rna_5.8s" in genome_data:
+            genome_data["rna_5_8s"] = genome_data["rna_5.8s"]
             genome_data.pop("rna_5.8s", None)
 
         return genome_data


### PR DESCRIPTION
This PR updates Genome.clean_data to to preserve rna_5.8s as rna_5_8s before removing it from the dataset