### PR TITLE
suspend_flow: wait for longer

### DIFF
--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -58,6 +58,9 @@ class SlurmConfig(BaseModel):
     preparation_command_job_memory_gb: int = 2
     # memory for jobs like `nextflow clean ...` or `rm -r ./work` that are run before bigger jobs
 
+    default_flow_suspend_awaiting_input_timeout_secs: int = 172800  # 2 days
+    # if a flow does suspend_flow_run(wait_for_input...), how long do we wait for it to be resumed before giving up?
+
 
 class MGnifyPipelineConfig(BaseModel):
     """

--- a/workflows/flows/analysis/assembly/flows/analysis_assembly_study.py
+++ b/workflows/flows/analysis/assembly/flows/analysis_assembly_study.py
@@ -108,7 +108,8 @@ def analysis_assembly_study(
 
                         {"**Webin owner** The study is private. Please provide the Webin account ID of the study owner so they can view their study." if needs_webin else ""}
                         """),
-            )
+            ),
+            timeout=EMG_CONFIG.slurm.default_flow_suspend_awaiting_input_timeout_secs,
         )
 
         biome = analyses.models.Biome.objects.get(path=analyse_study_input.biome.name)

--- a/workflows/flows/analysis_amplicon_study.py
+++ b/workflows/flows/analysis_amplicon_study.py
@@ -137,7 +137,8 @@ def analysis_amplicon_study(study_accession: str):
                 **Webin owner**
                 If the study is private, the webin account owner is needed so that the user can view the study they own.
                 """),
-        )
+        ),
+        timeout=EMG_CONFIG.slurm.default_flow_suspend_awaiting_input_timeout_secs,
     )
 
     ena_study, __ = validate_and_set_webin_owner(

--- a/workflows/flows/analysis_rawreads_study.py
+++ b/workflows/flows/analysis_rawreads_study.py
@@ -127,7 +127,8 @@ def analysis_rawreads_study(study_accession: str):
 
                 **Webin owner**
                 If the study is private, the webin account owner is needed so that the user can view the study they own.
-                """))
+                """)),
+        timeout=EMG_CONFIG.slurm.default_flow_suspend_awaiting_input_timeout_secs,
     )
 
     ena_study, __ = validate_and_set_webin_owner(

--- a/workflows/flows/assemble_study.py
+++ b/workflows/flows/assemble_study.py
@@ -156,7 +156,8 @@ def assemble_study(
                 If the study is private, the webin account owner is needed so that assemblies can be brokered into \
                 the reads study they own.
                 """),
-        )
+        ),
+        timeout=EMG_CONFIG.slurm.default_flow_suspend_awaiting_input_timeout_secs,
     )
 
     validate_and_set_webin_owner(ena_study, assemble_study_input.webin_owner)

--- a/workflows/flows/housekeeping/clean_nextflow_workdirs.py
+++ b/workflows/flows/housekeeping/clean_nextflow_workdirs.py
@@ -11,6 +11,8 @@ from prefect.artifacts import create_table_artifact
 from prefect.input import RunInput
 from pydantic import Field
 
+from activate_django_first import EMG_CONFIG
+
 
 class Workdir(TypedDict):
     """Shape of a candidate Nextflow work directory entry."""
@@ -219,7 +221,8 @@ def clean_old_nextflow_workdirs(
         wait_for_input=ConfirmDeletionInput.with_initial_data(
             confirm_deletion=False,
             description=description,
-        )
+        ),
+        timeout=EMG_CONFIG.slurm.default_flow_suspend_awaiting_input_timeout_secs,
     )
 
     if not confirm.confirm_deletion:

--- a/workflows/tests/test_analysis_amplicon_study_flow.py
+++ b/workflows/tests/test_analysis_amplicon_study_flow.py
@@ -1104,7 +1104,7 @@ def test_prefect_analyse_amplicon_flow(
         """))
 
     ## Pretend that a human resumed the flow with the biome picker.
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return analysis_study_input_mocker(
                 biome=biome_choices["root.engineered"],
@@ -1638,7 +1638,7 @@ def test_prefect_analyse_amplicon_flow_private_data(
     )
 
     ## Pretend that a human resumed the flow with the biome picker.
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return analysis_study_input_mocker(
                 biome=biome_choices["root.engineered"],

--- a/workflows/tests/test_analysis_assembly_study_flow.py
+++ b/workflows/tests/test_analysis_assembly_study_flow.py
@@ -584,7 +584,7 @@ def test_prefect_analyse_assembly_flow(
     )
 
     # Pretend that a human resumed the flow with the biome picker
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return analyse_study_input_mocker(
                 biome=biome_choices[assembly_test_scenario.biome_path],
@@ -957,7 +957,7 @@ def test_prefect_analyse_assembly_flow_missing_directory(
     )
 
     # Mock biome picker
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return analyse_study_input_mocker(
                 biome=biome_choices[scenario.biome_path],
@@ -1136,7 +1136,7 @@ def test_prefect_analyse_assembly_flow_invalid_schema(
     )
 
     # Mock biome picker
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return analyse_study_input_mocker(
                 biome=biome_choices[scenario.biome_path],
@@ -1225,7 +1225,7 @@ def test_private_assembly_study_requests_webin(
     mock_run_deployment.return_value = Mock(id="mock-flow-run-id")
 
     # Simulate a human resuming the flow and providing the webin_owner
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         """Return webin_owner when the flow suspends."""
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return analyse_study_input_mocker(

--- a/workflows/tests/test_analysis_rawreads_study_flow.py
+++ b/workflows/tests/test_analysis_rawreads_study_flow.py
@@ -546,7 +546,7 @@ def test_prefect_analyse_rawreads_flow(
         functional_analysis: bool
         webin_owner: Optional[str]
 
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return AnalyseStudyInput(
                 biome=BiomeChoices["root.engineered"],
@@ -1092,7 +1092,7 @@ def test_prefect_analyse_rawreads_flow_private_data(
         functional_analysis: bool
         webin_owner: Optional[str]
 
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return AnalyseStudyInput(
                 biome=BiomeChoices["root.engineered"],
@@ -1474,7 +1474,7 @@ def test_prefect_analyse_rawreads_flow_no_functional(
         functional_analysis: bool
         webin_owner: Optional[str]
 
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AnalyseStudyInput":
             return AnalyseStudyInput(
                 biome=BiomeChoices["root.engineered"],

--- a/workflows/tests/test_assemble_study_flow.py
+++ b/workflows/tests/test_assemble_study_flow.py
@@ -324,7 +324,7 @@ def test_prefect_assemble_study_flow(
         ],
     )
 
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AssembleStudyInput":
             return assembly_study_input_mocker(
                 biome=biome_choices["root.engineered"],
@@ -720,7 +720,7 @@ def test_prefect_assemble_private_study_flow(
     )
 
     ## Pretend that a human resumed the flow with the biome picker, and then with the assembler selector.
-    def suspend_side_effect(wait_for_input=None):
+    def suspend_side_effect(wait_for_input=None, **kwargs):
         if wait_for_input.__name__ == "AssembleStudyInput":
             return assembly_study_input_mocker(
                 biome=biome_choices["root.engineered"],


### PR DESCRIPTION
This PR:
* makes the (default) timeout for waiting for a suspended flowrun to be resumed (e.g. when waiting for input) be configurable 
* sets the default to 2 days instead of 1 hour

This should solve problems where HPC is busy, and so a flow-run doesn't start running in time for input to be given before the timeout


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [ ] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
