### PR TITLE
Add a comment to de-duplicate assemblies.

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -14,6 +14,9 @@ fileignoreconfig:
 - filename: analyses/models.py
   allowed_patterns: [key]
 
+- filename: analyses/management/commands/merge_assemblies_duplicates.py
+  checksum: 88d8816aedddb6d0303df338854a283092fbc2d697fc08d37f5838d3423814af
+
 - filename: analyses/management/commands/merge_ena_study_duplicates.py
   checksum: cbec9df9d7d9c07cceb95bd620bfd15fa7b7d938af0a1e67c68f6954be477389
 

--- a/analyses/management/commands/merge_assemblies_duplicates.py
+++ b/analyses/management/commands/merge_assemblies_duplicates.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from django.db import connection, transaction
+from pydantic import BaseModel, Field
+
+from analyses.models import Analysis, Assembly
+from genomes.models import AdditionalContainedGenomes, GenomeAssemblyLink
+
+
+class GroupMergeResult(BaseModel):
+    """Summary of one duplicate-assembly merge attempt."""
+
+    canonical_assembly: str
+    merged_assemblies: list[str]
+    deleted_assemblies: list[str] = Field(default_factory=list)
+    status: str = "dry_run"
+    error: str | None = None
+    grouped_accessions: list[str] = Field(default_factory=list)
+
+    def as_csv_row(self) -> dict[str, str]:
+        """Convert the merge result into one flat CSV row."""
+        return {
+            "grouped_accessions": ", ".join(self.grouped_accessions),
+            "canonical_assembly": self.canonical_assembly,
+            "merged_assemblies": ", ".join(self.merged_assemblies),
+            "deleted_assemblies": ", ".join(self.deleted_assemblies),
+            "status": self.status,
+            "error": self.error or "",
+        }
+
+
+class Command(BaseCommand):
+    help = "Deduplicate MGnify assemblies that share ENA accessions and write a CSV summary."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+        )
+        parser.add_argument(
+            "--accession",
+            action="append",
+            dest="accessions",
+            help="Limit processing to groups matching this ENA accession. Repeatable.",
+        )
+        parser.add_argument(
+            "--output-csv",
+            default="assembly_deduplication_summary.csv",
+            help="Path to the CSV report to write.",
+        )
+
+    def find_duplicated_assemblies(
+        self,
+        accessions: list[str] | None = None,
+    ) -> list[list[Assembly]]:
+        """
+        Load duplicate Assembly groups by overlapping ena_accessions values.
+
+        :param accessions: Optional ENA accessions used to limit which groups are returned.
+        :return: Duplicate groups whose accession arrays overlap transitively.
+        """
+        groups: list[list[Assembly]] = []
+        requested = set(accessions or [])
+
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                WITH RECURSIVE
+                -- 1. Expand each assembly row into one row per accession alias.
+                assembly_accessions AS (
+                    SELECT
+                        a.id AS assembly_id,
+                        unnest(a.ena_accessions) AS accession
+                    FROM analyses_assembly a
+                    WHERE cardinality(a.ena_accessions) > 0
+                ),
+                -- 2. Build graph edges between assemblies that share any accession.
+                assembly_links AS (
+                    SELECT DISTINCT
+                        a.assembly_id AS source_id,
+                        b.assembly_id AS target_id
+                    FROM assembly_accessions a
+                    JOIN assembly_accessions b
+                        ON a.accession = b.accession
+                ),
+                -- 3. Recursively walk the overlap graph from each assembly.
+                components AS (
+                    SELECT
+                        source_id AS root_id,
+                        source_id AS assembly_id
+                    FROM assembly_links
+                    UNION
+                    SELECT
+                        c.root_id,
+                        l.target_id AS assembly_id
+                    FROM components c
+                    JOIN assembly_links l
+                        ON l.source_id = c.assembly_id
+                ),
+                -- 4. Collapse each connected component to a stable component id.
+                grouped AS (
+                    SELECT
+                        MIN(root_id) AS component_id,
+                        assembly_id
+                    FROM components
+                    GROUP BY assembly_id
+                )
+                -- 5. Return one row per duplicate Assembly group.
+                SELECT
+                    array_agg(assembly_id ORDER BY assembly_id) AS assembly_ids
+                FROM grouped
+                GROUP BY component_id
+                HAVING COUNT(*) > 1
+                """)
+            duplicate_groups = [row[0] for row in cursor.fetchall()]
+
+        for assembly_ids in duplicate_groups:
+            group = list(
+                Assembly.objects.select_related(
+                    "sample",
+                    "reads_study",
+                    "assembly_study",
+                    "assembler",
+                    "ena_study",
+                )
+                .filter(id__in=assembly_ids)
+                .order_by("id")
+            )
+
+            if requested and not any(
+                bool(requested.intersection(set(assembly.ena_accessions)))
+                for assembly in group
+            ):
+                continue
+
+            groups.append(group)
+        return groups
+
+    def update_assembly_accessions(
+        self, canonical: Assembly, duplicates: list[Assembly]
+    ) -> None:
+        """
+        Union ENA accession aliases onto the canonical Assembly.
+
+        :param canonical: The Assembly row that will be kept.
+        :param duplicates: Assembly rows that will be merged into the canonical one.
+        """
+        all_accessions = set(canonical.ena_accessions or [])
+        for duplicate in duplicates:
+            all_accessions.update(duplicate.ena_accessions or [])
+
+        merged_accessions = sorted(all_accessions)
+        if sorted(canonical.ena_accessions or []) != merged_accessions:
+            canonical.ena_accessions = merged_accessions
+            canonical.save(update_fields=["ena_accessions"])
+
+    def merge_assembly_fields(
+        self, canonical: Assembly, duplicates: list[Assembly]
+    ) -> None:
+        """
+        Preserve assembly-owned fields from duplicates before deleting them.
+
+        :param canonical: The Assembly row that will be kept.
+        :param duplicates: Assembly rows that will be merged into the canonical one.
+        """
+        updated = False
+
+        for duplicate in duplicates:
+            for attr_name, update_field in [
+                ("dir", "dir"),
+                ("sample_id", "sample"),
+                ("reads_study_id", "reads_study"),
+                ("assembly_study_id", "assembly_study"),
+                ("assembler_id", "assembler"),
+                ("ena_study_id", "ena_study"),
+                ("webin_submitter", "webin_submitter"),
+            ]:
+                if not getattr(canonical, attr_name) and getattr(duplicate, attr_name):
+                    setattr(canonical, attr_name, getattr(duplicate, attr_name))
+                    updated = True
+
+            merged_metadata = {
+                **(duplicate.metadata or {}),
+                **(canonical.metadata or {}),
+            }
+            if canonical.metadata != merged_metadata:
+                canonical.metadata = merged_metadata
+                updated = True
+
+            merged_status = {
+                **(canonical.status or {}),
+                **{
+                    key: value
+                    for key, value in (duplicate.status or {}).items()
+                    if key not in (canonical.status or {})
+                },
+            }
+            for key, value in (duplicate.status or {}).items():
+                if isinstance(value, bool) and value:
+                    merged_status[key] = True
+
+            if canonical.status != merged_status:
+                canonical.status = merged_status
+                updated = True
+
+            if duplicate.is_private and not canonical.is_private:
+                canonical.is_private = True
+                updated = True
+            if duplicate.is_suppressed and not canonical.is_suppressed:
+                canonical.is_suppressed = True
+                updated = True
+
+        if updated:
+            canonical.save()
+
+    def rewire_assembly_relations(
+        self, canonical_assembly: Assembly, duplicates: list[Assembly]
+    ) -> None:
+        """
+        Reassign direct Assembly relations from duplicate Assemblies to the canonical Assembly.
+
+        It reassigns the assembly links to Runs and Genomes.
+
+        :param canonical_assembly: The Assembly row that will be kept.
+        :param duplicates: Assembly rows that will be merged into the canonical one.
+        """
+        assembly_run_through = Assembly.runs.through
+
+        for duplicate in duplicates:
+            # -- Runs -- #
+            duplicate_run_ids = list(
+                assembly_run_through.objects.filter(
+                    assembly_id=duplicate.id
+                ).values_list("run_id", flat=True)
+            )
+            assembly_run_through.objects.bulk_create(
+                [
+                    assembly_run_through(
+                        assembly_id=canonical_assembly.id,
+                        run_id=run_id,
+                    )
+                    for run_id in duplicate_run_ids
+                ],
+                ignore_conflicts=True,
+            )
+            assembly_run_through.objects.filter(assembly_id=duplicate.id).delete()
+
+            if Analysis.objects.filter(assembly=duplicate).exists():
+                Analysis.objects.filter(assembly=duplicate).update(
+                    assembly=canonical_assembly
+                )
+
+            # -- Genomes -- #
+            duplicate_genome_links = list(
+                GenomeAssemblyLink.objects.filter(assembly=duplicate)
+            )
+            GenomeAssemblyLink.objects.bulk_create(
+                [
+                    GenomeAssemblyLink(
+                        genome=link.genome,
+                        # Re-assign
+                        assembly=canonical_assembly,
+                        species_rep=link.species_rep,
+                        mag_accession=link.mag_accession,
+                    )
+                    for link in duplicate_genome_links
+                ],
+                ignore_conflicts=True,
+            )
+            GenomeAssemblyLink.objects.filter(assembly=duplicate).delete()
+
+            duplicate_contained_genomes = list(
+                AdditionalContainedGenomes.objects.filter(assembly=duplicate)
+            )
+            AdditionalContainedGenomes.objects.bulk_create(
+                [
+                    AdditionalContainedGenomes(
+                        run=contained.run,
+                        genome=contained.genome,
+                        assembly=canonical_assembly,
+                        containment=contained.containment,
+                        cani=contained.cani,
+                    )
+                    for contained in duplicate_contained_genomes
+                ],
+                ignore_conflicts=True,
+            )
+            AdditionalContainedGenomes.objects.filter(assembly=duplicate).delete()
+
+    def assembly_is_fully_detached(self, assembly: Assembly) -> bool:
+        """
+        Check whether an Assembly has any remaining direct relations that block deletion.
+
+        :param assembly: Assembly row being considered for deletion after rewiring.
+        :return: True if no direct tracked relations remain attached.
+        """
+        return not any(
+            [
+                assembly.runs.exists(),
+                assembly.analyses.exists(),
+                assembly.genome_links.exists(),
+                assembly.additional_contained_genomes.exists(),
+            ]
+        )
+
+    def merge_duplicate_group(
+        self,
+        assemblies: list[Assembly],
+        dry_run: bool = True,
+    ) -> GroupMergeResult:
+        """
+        Merge one duplicate Assembly group onto a single canonical Assembly.
+
+        :param assemblies: Duplicate Assembly rows in one connected component.
+        :param dry_run: If True, calculate merge actions without persisting them.
+        :return: Summary of the merge outcome for reporting.
+        """
+        canonical_assembly = sorted(assemblies, key=lambda assembly: assembly.id)[0]
+        duplicates = [
+            assembly for assembly in assemblies if assembly.pk != canonical_assembly.pk
+        ]
+
+        grouped_accessions = sorted(
+            {
+                accession
+                for assembly in assemblies
+                for accession in assembly.ena_accessions
+            }
+        )
+
+        result = GroupMergeResult(
+            canonical_assembly=canonical_assembly.first_accession
+            or str(canonical_assembly.id),
+            merged_assemblies=[
+                assembly.first_accession or str(assembly.id) for assembly in assemblies
+            ],
+            deleted_assemblies=[
+                assembly.first_accession or str(assembly.id) for assembly in duplicates
+            ],
+            grouped_accessions=grouped_accessions,
+            status="dry_run" if dry_run else "applied",
+        )
+
+        if dry_run:
+            self.stdout.write(
+                f"Dry run: Would merge {len(duplicates)} assemblies into {canonical_assembly}"
+            )
+            return result
+
+        with transaction.atomic():
+            self.update_assembly_accessions(canonical_assembly, duplicates)
+            self.merge_assembly_fields(canonical_assembly, duplicates)
+            self.rewire_assembly_relations(canonical_assembly, duplicates)
+
+            deleted_assemblies: list[str] = []
+            for duplicate in duplicates:
+                duplicate.refresh_from_db()
+                if self.assembly_is_fully_detached(duplicate):
+                    deleted_assemblies.append(
+                        duplicate.first_accession or str(duplicate.id)
+                    )
+                    duplicate.delete()
+                else:
+                    raise ValueError(
+                        f"Assembly {duplicate} is still connected to other objects and cannot be deleted."
+                    )
+            result.deleted_assemblies = deleted_assemblies
+
+        return result
+
+    def write_results_csv(self, rows: list[dict[str, str]], output_path: Path) -> Path:
+        """
+        Persist deduplication results as a CSV report.
+
+        :param rows: Flat rows describing each processed duplicate group.
+        :param output_path: Destination CSV path.
+        :return: The written output path.
+        """
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fieldnames = [
+            "grouped_accessions",
+            "canonical_assembly",
+            "merged_assemblies",
+            "deleted_assemblies",
+            "status",
+            "error",
+        ]
+        with output_path.open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+        return output_path
+
+    def deduplicate_assemblies(
+        self,
+        accessions: list[str] | None = None,
+        dry_run: bool = True,
+        output_csv: str | Path | None = None,
+    ) -> list[dict[str, str]]:
+        """
+        Deduplicate MGnify Assembly rows and emit a summary.
+
+        :param accessions: Optional ENA accessions used to limit processing to matching groups.
+        :param dry_run: If True, report intended changes without persisting them.
+        :param output_csv: Destination for the CSV summary report.
+        :return: Flat rows describing every processed duplicate group.
+        """
+        duplicated_assemblies = self.find_duplicated_assemblies(accessions=accessions)
+        self.stdout.write(
+            f"Found {len(duplicated_assemblies)} duplicate assemblies to process"
+            + (" in dry-run mode" if dry_run else "")
+        )
+
+        results: list[GroupMergeResult] = []
+        for index, assemblies in enumerate(duplicated_assemblies, start=1):
+            self.stdout.write(
+                f"Processing assembly group {index}/{len(duplicated_assemblies)}: "
+                f"{', '.join(assembly.first_accession or str(assembly.id) for assembly in assemblies)}"
+            )
+            try:
+                result = self.merge_duplicate_group(assemblies, dry_run=dry_run)
+                results.append(result)
+                self.stdout.write(
+                    f"Finished group {index}/{len(duplicated_assemblies)} "
+                    f"with canonical assembly {result.canonical_assembly}"
+                )
+            except Exception as exc:
+                self.stderr.write(
+                    self.style.ERROR(
+                        f"Failed to deduplicate assembly group {[assembly.id for assembly in assemblies]}: {exc}"
+                    )
+                )
+                results.append(
+                    GroupMergeResult(
+                        canonical_assembly=assemblies[0].first_accession
+                        or str(assemblies[0].id),
+                        merged_assemblies=[
+                            assembly.first_accession or str(assembly.id)
+                            for assembly in assemblies
+                        ],
+                        grouped_accessions=sorted(
+                            {
+                                accession
+                                for assembly in assemblies
+                                for accession in assembly.ena_accessions
+                            }
+                        ),
+                        status="failed",
+                        error=str(exc),
+                    )
+                )
+                continue
+
+        csv_rows = [result.as_csv_row() for result in results]
+        output_path = (
+            Path(output_csv)
+            if output_csv
+            else Path.cwd() / "assembly_deduplication_summary.csv"
+        )
+        self.write_results_csv(csv_rows, output_path)
+        self.stdout.write(f"Wrote assembly deduplication summary to {output_path}")
+        return csv_rows
+
+    def handle(self, *args, **options):
+        self.deduplicate_assemblies(
+            accessions=options["accessions"],
+            dry_run=options["dry_run"],
+            output_csv=options["output_csv"],
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Assembly deduplication summary written to {options['output_csv']}"
+            )
+        )

--- a/analyses/management/commands/merge_assemblies_duplicates.py
+++ b/analyses/management/commands/merge_assemblies_duplicates.py
@@ -37,9 +37,19 @@ class Command(BaseCommand):
     help = "Deduplicate MGnify assemblies that share ENA accessions and write a CSV summary."
 
     def add_arguments(self, parser):
-        parser.add_argument(
+        mode_group = parser.add_mutually_exclusive_group()
+        mode_group.add_argument(
             "--dry-run",
             action="store_true",
+            dest="dry_run",
+            default=True,
+            help="Report intended changes without modifying the database (default).",
+        )
+        mode_group.add_argument(
+            "--apply",
+            action="store_false",
+            dest="dry_run",
+            help="Apply deduplication changes to the database.",
         )
         parser.add_argument(
             "--accession",

--- a/analyses/management/commands/merge_ena_study_duplicates.py
+++ b/analyses/management/commands/merge_ena_study_duplicates.py
@@ -38,9 +38,19 @@ class Command(BaseCommand):
     help = "Deduplicate ENA Study rows that share accessions and write a CSV summary."
 
     def add_arguments(self, parser):
-        parser.add_argument(
+        mode_group = parser.add_mutually_exclusive_group()
+        mode_group.add_argument(
             "--dry-run",
             action="store_true",
+            dest="dry_run",
+            default=True,
+            help="Report intended changes without modifying the database (default).",
+        )
+        mode_group.add_argument(
+            "--apply",
+            action="store_false",
+            dest="dry_run",
+            help="Apply deduplication changes to the database.",
         )
         parser.add_argument(
             "--accession",

--- a/analyses/management/commands/merge_mgys_duplicates.py
+++ b/analyses/management/commands/merge_mgys_duplicates.py
@@ -64,9 +64,19 @@ class Command(BaseCommand):
         return {accession for accession in accessions if accession}
 
     def add_arguments(self, parser):
-        parser.add_argument(
+        mode_group = parser.add_mutually_exclusive_group()
+        mode_group.add_argument(
             "--dry-run",
             action="store_true",
+            dest="dry_run",
+            default=True,
+            help="Report intended changes without modifying the database (default).",
+        )
+        mode_group.add_argument(
+            "--apply",
+            action="store_false",
+            dest="dry_run",
+            help="Apply deduplication changes to the database.",
         )
         parser.add_argument(
             "--accession",

--- a/analyses/management/commands/merge_runs_duplicates.py
+++ b/analyses/management/commands/merge_runs_duplicates.py
@@ -36,9 +36,19 @@ class Command(BaseCommand):
     help = "Deduplicate MGnify runs that share ENA accessions and write a CSV summary."
 
     def add_arguments(self, parser):
-        parser.add_argument(
+        mode_group = parser.add_mutually_exclusive_group()
+        mode_group.add_argument(
             "--dry-run",
             action="store_true",
+            dest="dry_run",
+            default=True,
+            help="Report intended changes without modifying the database (default).",
+        )
+        mode_group.add_argument(
+            "--apply",
+            action="store_false",
+            dest="dry_run",
+            help="Apply deduplication changes to the database.",
         )
         parser.add_argument(
             "--accession",

--- a/analyses/tests/test_merge_assemblies_duplicates.py
+++ b/analyses/tests/test_merge_assemblies_duplicates.py
@@ -1,0 +1,223 @@
+import csv
+
+import pytest
+from django.core.management import call_command
+
+from analyses.management.commands.merge_assemblies_duplicates import Command
+from analyses.models import Analysis, Assembly, Run
+
+
+@pytest.fixture
+def assembly_pair(raw_reads_mgnify_study, raw_reads_mgnify_sample):
+    raw_reads_sample, *_ = raw_reads_mgnify_sample
+    assembly_kwargs = {
+        "ena_study": raw_reads_mgnify_study.ena_study,
+        "sample": raw_reads_sample,
+        "reads_study": raw_reads_mgnify_study,
+        # At the moment of writing this, there are no assemblies with more than one accession in ena_accesions
+        # but the code should cope with that anyway.
+        "ena_accessions": ["ERZ100001", "GCA100101"],
+    }
+    return Assembly.objects.create(**assembly_kwargs), Assembly.objects.create(
+        **assembly_kwargs
+    )
+
+
+@pytest.mark.django_db
+def test_find_duplicated_assemblies_returns_matching_pair(assembly_pair):
+    """Finds assemblies with the same full accession set."""
+    assembly_old, assembly_new = assembly_pair
+
+    groups = Command().find_duplicated_assemblies()
+
+    assert len(groups) == 1
+    assert [assembly.id for assembly in groups[0]] == [
+        assembly_old.id,
+        assembly_new.id,
+    ]
+
+
+@pytest.mark.django_db
+def test_find_duplicated_assemblies_returns_overlap_pair(
+    raw_reads_mgnify_study,
+    raw_reads_mgnify_sample,
+):
+    """Finds assemblies when one accession set overlaps another."""
+    raw_reads_sample, *_ = raw_reads_mgnify_sample
+    assembly_old = Assembly.objects.create(
+        ena_study=raw_reads_mgnify_study.ena_study,
+        sample=raw_reads_sample,
+        reads_study=raw_reads_mgnify_study,
+        ena_accessions=["ERZ100101", "GCA100101"],
+    )
+    assembly_new = Assembly.objects.create(
+        ena_study=raw_reads_mgnify_study.ena_study,
+        sample=raw_reads_sample,
+        reads_study=raw_reads_mgnify_study,
+        ena_accessions=["ERZ100101"],
+    )
+    Assembly.objects.create(
+        ena_study=raw_reads_mgnify_study.ena_study,
+        sample=raw_reads_sample,
+        reads_study=raw_reads_mgnify_study,
+        ena_accessions=["ERZ100102"],
+    )
+
+    groups = Command().find_duplicated_assemblies()
+
+    assert len(groups) == 1
+    assert [assembly.id for assembly in groups[0]] == [
+        assembly_old.id,
+        assembly_new.id,
+    ]
+
+
+@pytest.mark.django_db
+def test_find_duplicated_assemblies_ignores_assemblies_without_ena_accessions(
+    raw_reads_mgnify_study,
+    raw_reads_mgnify_sample,
+):
+    """Ignores unaccessioned assemblies instead of grouping all empty arrays."""
+    raw_reads_sample, *_ = raw_reads_mgnify_sample
+    Assembly.objects.create(
+        ena_study=raw_reads_mgnify_study.ena_study,
+        sample=raw_reads_sample,
+        reads_study=raw_reads_mgnify_study,
+        ena_accessions=[],
+    )
+    Assembly.objects.create(
+        ena_study=raw_reads_mgnify_study.ena_study,
+        sample=raw_reads_sample,
+        reads_study=raw_reads_mgnify_study,
+        ena_accessions=[],
+    )
+
+    groups = Command().find_duplicated_assemblies()
+
+    assert groups == []
+
+
+@pytest.mark.django_db
+def test_merge_assemblies_duplicates_dry_run_leaves_data_unchanged(
+    assembly_pair,
+    tmp_path,
+):
+    """Reports duplicate assemblies without changing data in dry-run mode."""
+    assembly_old, assembly_new = assembly_pair
+    report_path = tmp_path / "dry-run-report.csv"
+
+    call_command(
+        "merge_assemblies_duplicates",
+        "--dry-run",
+        "--output-csv",
+        str(report_path),
+    )
+
+    assert Assembly.objects.filter(id=assembly_old.id).exists()
+    assert Assembly.objects.filter(id=assembly_new.id).exists()
+    with report_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) == 1
+    assert rows[0]["status"] == "dry_run"
+    assert rows[0]["canonical_assembly"] == (
+        assembly_old.first_accession or str(assembly_old.id)
+    )
+
+
+@pytest.mark.django_db
+def test_merge_assemblies_duplicates_rewires_relations_and_merges_fields(
+    assembly_pair,
+    raw_reads_mgnify_study,
+    raw_reads_mgnify_sample,
+    tmp_path,
+):
+    """Reassigns related analyses and runs to the canonical assembly."""
+    raw_reads_sample, *_ = raw_reads_mgnify_sample
+
+    assembly_old, assembly_new = assembly_pair
+
+    assembly_old.metadata = {"keep": "me"}
+    assembly_old.status = {"assembly_started": False}
+    assembly_old.save()
+
+    assembly_new.metadata = {"duplicate": "value"}
+    assembly_new.status = {"assembly_started": True, "assembly_completed": True}
+    assembly_new.save()
+
+    run = Run.objects.create(
+        ena_study=raw_reads_mgnify_study.ena_study,
+        study=raw_reads_mgnify_study,
+        sample=raw_reads_sample,
+        ena_accessions=["ERR-ASSEMBLY-DUP"],
+    )
+
+    assembly_new.runs.add(run)
+    analysis = Analysis.objects.create(
+        study=raw_reads_mgnify_study,
+        sample=raw_reads_sample,
+        assembly=assembly_new,
+        ena_study=raw_reads_mgnify_study.ena_study,
+    )
+    report_path = tmp_path / "applied-report.csv"
+
+    call_command("merge_assemblies_duplicates", "--output-csv", str(report_path))
+
+    assembly_old.refresh_from_db()
+    analysis.refresh_from_db()
+
+    assert not Assembly.objects.filter(id=assembly_new.id).exists()
+
+    assert analysis.assembly_id == assembly_old.id
+    assert assembly_old.runs.filter(id=run.id).exists()
+
+    assert sorted(assembly_old.ena_accessions) == ["ERZ100001", "GCA100101"]
+
+    assert assembly_old.metadata == {"duplicate": "value", "keep": "me"}
+    assert assembly_old.status["assembly_started"] is True
+    assert assembly_old.status["assembly_completed"] is True
+
+    with report_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    assert len(rows) == 1
+    assert rows[0]["status"] == "applied"
+    assert rows[0]["deleted_assemblies"] == (
+        assembly_new.first_accession or str(assembly_new.id)
+    )
+
+
+@pytest.mark.django_db
+def test_merge_assemblies_duplicates_accession_filter_limits_groups(
+    assembly_pair,
+    raw_reads_mgnify_study,
+    raw_reads_mgnify_sample,
+    tmp_path,
+):
+    """
+    Tests that the command handles accessions filtering correctly.
+    """
+    target_old, target_new = assembly_pair
+    raw_reads_sample, *_ = raw_reads_mgnify_sample
+    other_old = Assembly.objects.create(
+        ena_study=raw_reads_mgnify_study.ena_study,
+        sample=raw_reads_sample,
+        reads_study=raw_reads_mgnify_study,
+        ena_accessions=["ERZ100201"],
+    )
+    other_new = Assembly.objects.create(
+        ena_study=raw_reads_mgnify_study.ena_study,
+        sample=raw_reads_sample,
+        reads_study=raw_reads_mgnify_study,
+        ena_accessions=["ERZ100201"],
+    )
+
+    call_command(
+        "merge_assemblies_duplicates",
+        "--accession",
+        target_old.first_accession,
+        "--output-csv",
+        str(tmp_path / "filtered-report.csv"),
+    )
+
+    assert Assembly.objects.filter(id=target_new.id).exists() is False
+    assert Assembly.objects.filter(id=other_old.id).exists() is True
+    assert Assembly.objects.filter(id=other_new.id).exists() is True

--- a/analyses/tests/test_merge_assemblies_duplicates.py
+++ b/analyses/tests/test_merge_assemblies_duplicates.py
@@ -108,7 +108,6 @@ def test_merge_assemblies_duplicates_dry_run_leaves_data_unchanged(
 
     call_command(
         "merge_assemblies_duplicates",
-        "--dry-run",
         "--output-csv",
         str(report_path),
     )
@@ -160,7 +159,9 @@ def test_merge_assemblies_duplicates_rewires_relations_and_merges_fields(
     )
     report_path = tmp_path / "applied-report.csv"
 
-    call_command("merge_assemblies_duplicates", "--output-csv", str(report_path))
+    call_command(
+        "merge_assemblies_duplicates", "--apply", "--output-csv", str(report_path)
+    )
 
     assembly_old.refresh_from_db()
     analysis.refresh_from_db()
@@ -212,6 +213,7 @@ def test_merge_assemblies_duplicates_accession_filter_limits_groups(
 
     call_command(
         "merge_assemblies_duplicates",
+        "--apply",
         "--accession",
         target_old.first_accession,
         "--output-csv",

--- a/analyses/tests/test_merge_ena_study_duplicates.py
+++ b/analyses/tests/test_merge_ena_study_duplicates.py
@@ -52,7 +52,6 @@ def test_merge_ena_study_duplicates_dry_run_leaves_data_unchanged(
 
     call_command(
         "merge_ena_study_duplicates",
-        "--dry-run",
         "--output-csv",
         str(report_path),
     )
@@ -111,7 +110,9 @@ def test_merge_ena_study_duplicates_rewires_relations_and_deletes_duplicate(
     )
     report_path = tmp_path / "applied-report.csv"
 
-    call_command("merge_ena_study_duplicates", "--output-csv", str(report_path))
+    call_command(
+        "merge_ena_study_duplicates", "--apply", "--output-csv", str(report_path)
+    )
 
     canonical_ena_study.refresh_from_db()
     mg_study.refresh_from_db()

--- a/analyses/tests/test_merge_mgys_duplicates.py
+++ b/analyses/tests/test_merge_mgys_duplicates.py
@@ -133,7 +133,6 @@ def test_merge_mgys_duplicates_dry_run_leaves_data_unchanged(tmp_path, study_pai
 
     call_command(
         "merge_mgys_duplicates",
-        "--dry-run",
         "--output-csv",
         str(report_path),
     )
@@ -215,7 +214,7 @@ def test_merge_mgys_duplicates_rewires_relations(tmp_path, study_pair):
     SuperStudyStudy.objects.create(study=study_new, super_study=super_study)
     report_path = tmp_path / "applied-report.csv"
 
-    call_command("merge_mgys_duplicates", "--output-csv", str(report_path))
+    call_command("merge_mgys_duplicates", "--apply", "--output-csv", str(report_path))
 
     study_old.refresh_from_db()
     mg_sample.refresh_from_db()
@@ -273,6 +272,7 @@ def test_merge_mgys_duplicates_accepts_partial_ena_accession_aliases(tmp_path):
 
     call_command(
         "merge_mgys_duplicates",
+        "--apply",
         "--output-csv",
         str(tmp_path / "partial-alias-report.csv"),
     )
@@ -298,6 +298,7 @@ def test_merge_mgys_duplicates_accession_filter_limits_groups(tmp_path, study_pa
 
     call_command(
         "merge_mgys_duplicates",
+        "--apply",
         "--accession",
         target_old.first_accession,
         "--output-csv",
@@ -336,6 +337,7 @@ def test_merge_mgys_duplicates_reconciles_overlapping_runs(tmp_path, study_pair)
 
     call_command(
         "merge_mgys_duplicates",
+        "--apply",
         "--output-csv",
         str(tmp_path / "overlapping-runs-report.csv"),
     )

--- a/analyses/tests/test_merge_runs_duplicates.py
+++ b/analyses/tests/test_merge_runs_duplicates.py
@@ -73,7 +73,6 @@ def test_merge_runs_duplicates_dry_run_leaves_data_unchanged(
 
     call_command(
         "merge_runs_duplicates",
-        "--dry-run",
         "--output-csv",
         str(report_path),
     )
@@ -113,7 +112,7 @@ def test_merge_runs_duplicates_rewires_relations(
     )
     report_path = tmp_path / "applied-report.csv"
 
-    call_command("merge_runs_duplicates", "--output-csv", str(report_path))
+    call_command("merge_runs_duplicates", "--apply", "--output-csv", str(report_path))
 
     analysis.refresh_from_db()
     assembly.refresh_from_db()


### PR DESCRIPTION
This PR add as a management command to de-duplicate assemblies. This is shouldn't happen any more as https://github.com/EBI-Metagenomics/emgapi-v2/pull/362 introduced a change on how the `get_or_create` works for `ENADerivedModels`.

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [ ] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
