### PR TITLE
Added use-regex annotaion to branchwater path

### DIFF
--- a/deployment/ebi-wp-k8s-hl/ebi-wp-k8s-hl.yaml
+++ b/deployment/ebi-wp-k8s-hl/ebi-wp-k8s-hl.yaml
@@ -350,6 +350,7 @@ items:
       namespace: emgapiv2-hl-exp
       annotations:
         kubernetes.io/ingress.class: "nginx"
+        nginx.ingress.kubernetes.io/use-regex: "true"
         nginx.ingress.kubernetes.io/rewrite-target: /$1
         nginx.ingress.kubernetes.io/service-upstream: "true"
     spec:


### PR DESCRIPTION
Branchwater url paths were being treated as plain text. This causes 404 errors when requests are made. 
This PR:
adds the nginx.ingress.kubernetes.io/use-regex annotation values, so Branchwater paths are treated as regex.
*


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
