### PR TITLE
Increase timeout allowance on Branchwater

### DIFF
--- a/deployment/ebi-wp-k8s-hl/ebi-wp-k8s-hl.yaml
+++ b/deployment/ebi-wp-k8s-hl/ebi-wp-k8s-hl.yaml
@@ -353,6 +353,9 @@ items:
         nginx.ingress.kubernetes.io/use-regex: "true"
         nginx.ingress.kubernetes.io/rewrite-target: /$1
         nginx.ingress.kubernetes.io/service-upstream: "true"
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "360"
+        nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     spec:
       rules:
         - host: www.ebi.ac.uk


### PR DESCRIPTION
This PR:
*
Increases timeout allowance on Branchwater


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
