### PR TITLE
adds rss feed of latest analysed studies

### DIFF
--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -288,6 +288,13 @@ class ServiceURLsConfig(BaseModel):
     genome_search_proxy: str = "https://cobs-genome-search-01.mgnify.org/search"
 
 
+class DataDistributionConfig(BaseModel):
+    studies_url_root_for_permalinks: str = Field(
+        "https://www.ebi.ac.uk/metagenomics/studies/"
+    )
+    latest_studies_feed_count: int = 20
+
+
 class MaskReplacement(BaseModel):
     match: Pattern = Field(
         ..., description="A compiled regex pattern which, when matched, will be masked"
@@ -330,9 +337,6 @@ class DarwinCoreArchiveConfig(BaseModel):
         "EMBL-EBI's MGnify imposes no additional restriction on the use of the contributed data than those provided by the data owner."
     )
     keywords: list[str] = Field(["metagenomics", "environmental genomics"])
-    studies_url_root_for_distribution: str = Field(
-        "https://www.ebi.ac.uk/metagenomics/studies/"
-    )
 
 
 class RequestTrackerConfig(BaseModel):
@@ -362,6 +366,7 @@ class EMGConfig(BaseSettings):
     darwin_core_archive: DarwinCoreArchiveConfig = DarwinCoreArchiveConfig()
     rt: RequestTrackerConfig = RequestTrackerConfig()
     sentry_dsn: str = ""
+    distribution: DataDistributionConfig = DataDistributionConfig()
 
     model_config = SettingsConfigDict(
         env_prefix="emg_",

--- a/emgapiv2/feeds.py
+++ b/emgapiv2/feeds.py
@@ -1,0 +1,41 @@
+from urllib.parse import urljoin
+
+from django.conf import settings
+from django.contrib.syndication.views import Feed
+
+from analyses.models import Study
+
+
+class LatestStudiesFeed(Feed):
+    title = "MGnify Latest Studies"
+    link = "/studies/"
+    description = "Latest studies analysed by MGnify pipelines"
+
+    def items(self):
+        return Study.public_objects.order_by("-updated_at")[
+            : settings.EMG_CONFIG.distribution.latest_studies_feed_count
+        ]
+
+    def item_title(self, item: Study):
+        return f"{item.accession}: {item.title}"
+
+    def item_description(self, item: Study):
+        return f"{' | '.join(item.ena_accessions)}: {item.metadata.get('study_description', 'No description available.')}"
+
+    def item_link(self, item: Study):
+        return urljoin(
+            settings.EMG_CONFIG.distribution.studies_url_root_for_permalinks,
+            item.accession,
+        )
+
+    def item_author_name(self, item: Study):
+        return item.metadata.get("center_name", "No submission centre available.")
+
+    def item_pubdate(self, item: Study):
+        return item.created_at
+
+    def item_updateddate(self, item: Study):
+        return item.updated_at
+
+    def item_categories(self, item: Study):
+        return [item.biome.biome_name]

--- a/emgapiv2/test_feeds.py
+++ b/emgapiv2/test_feeds.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_public_studies_feed(webin_private_study, raw_reads_mgnify_study, client):
+    response = client.get("/rss/studies/")
+    assert response.status_code == 200
+    content = response.content.decode("utf-8")
+    assert content.startswith("<?xml")
+    assert raw_reads_mgnify_study.accession in content
+    assert webin_private_study.accession not in content

--- a/emgapiv2/urls.py
+++ b/emgapiv2/urls.py
@@ -24,6 +24,7 @@ from analyses.admin.study import (
     study_refresh_batch_counts_admin,
 )
 
+from . import feeds
 from .api import api
 
 BASE_URL = settings.BASE_URL
@@ -54,6 +55,7 @@ urlpatterns = [
     path(f"{BASE_URL}__debug__/", include("debug_toolbar.urls")),
     path(f"{BASE_URL}fieldfiles/", include("db_file_storage.urls")),
     path(BASE_URL, api.urls),
+    path(f"{BASE_URL}rss/studies/", feeds.LatestStudiesFeed()),
     path(f"{BASE_URL}workflows/", include("workflows.urls")),
 ]
 admin.site.index_title = "EMG DB Administration"

--- a/workflows/flows/analyse_study_tasks/shared/dwca_generator.py
+++ b/workflows/flows/analyse_study_tasks/shared/dwca_generator.py
@@ -93,7 +93,7 @@ def convert_dwcr_to_dwca(
         distribution=Distribution(
             online=DistributionOnline(
                 url=urljoin(
-                    EMG_CONFIG.darwin_core_archive.studies_url_root_for_distribution,
+                    EMG_CONFIG.distribution.studies_url_root_for_permalinks,
                     study.accession,
                 )
             )


### PR DESCRIPTION
This PR:
* adds an RSS feed of the latest public studies
* mostly because _I wanted this feature_ ... but PDBe and EBISearch also provide RSS feeds so it is with precedent 


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
