### PR TITLE
Better library source/strategy control

### DIFF
--- a/analyses/base_models/base_models.py
+++ b/analyses/base_models/base_models.py
@@ -271,7 +271,7 @@ class InferredMetadataMixin:
     INFERRED = "INFERRED"
 
     class _MetadataDictPreferringInferred(dict):
-        def get(self, __key):
+        def get(self, __key, default=None):
             for potential_key in [
                 f"{InferredMetadataMixin.INFERRED}_{__key}",
                 f"{InferredMetadataMixin.INFERRED.lower()}_{__key}",
@@ -281,7 +281,7 @@ class InferredMetadataMixin:
                         f"Using inferred value of {__key}, because {potential_key} found in {self}"
                     )
                     return super().get(potential_key)
-            return super().get(__key)
+            return super().get(__key, default)
 
         def __getitem__(self, item):
             return self.get(item)

--- a/analyses/management/commands/determine_unknown_run_experiment_types.py
+++ b/analyses/management/commands/determine_unknown_run_experiment_types.py
@@ -155,7 +155,9 @@ class Command(BaseCommand):
             "analysis_accessions": ",".join(
                 run.analyses.order_by("accession").values_list("accession", flat=True)
             ),
-            "library_strategy": metadata.get(Run.CommonMetadataKeys.LIBRARY_STRATEGY, ""),
+            "library_strategy": metadata.get(
+                Run.CommonMetadataKeys.LIBRARY_STRATEGY, ""
+            ),
             "library_source": metadata.get(Run.CommonMetadataKeys.LIBRARY_SOURCE) or "",
             "scientific_name": metadata.get(Run.CommonMetadataKeys.SCIENTIFIC_NAME)
             or "",

--- a/analyses/management/commands/determine_unknown_run_experiment_types.py
+++ b/analyses/management/commands/determine_unknown_run_experiment_types.py
@@ -155,8 +155,7 @@ class Command(BaseCommand):
             "analysis_accessions": ",".join(
                 run.analyses.order_by("accession").values_list("accession", flat=True)
             ),
-            "library_strategy": metadata.get(Run.CommonMetadataKeys.LIBRARY_STRATEGY)
-            or "",
+            "library_strategy": metadata.get(Run.CommonMetadataKeys.LIBRARY_STRATEGY, ""),
             "library_source": metadata.get(Run.CommonMetadataKeys.LIBRARY_SOURCE) or "",
             "scientific_name": metadata.get(Run.CommonMetadataKeys.SCIENTIFIC_NAME)
             or "",

--- a/analyses/management/commands/determine_unknown_run_experiment_types.py
+++ b/analyses/management/commands/determine_unknown_run_experiment_types.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import csv
+import logging
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+
+from analyses.models import Analysis, Run
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = (
+        "Determine UNKNOWN run experiment types from analyses, assemblies, or ENA "
+        "metadata, and write a TSV report of changed and unresolved runs."
+    )
+
+    report_headers = [
+        "run_accession",
+        "study_accession",
+        "analysis_accessions",
+        "library_strategy",
+        "library_source",
+        "scientific_name",
+        "previous_experiment_type",
+        "new_experiment_type",
+        "status",
+        "reason",
+    ]
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--output-tsv",
+            default="unknown_run_experiment_type_report.tsv",
+            help="Path to the TSV report to write.",
+        )
+
+    def handle(self, *args, **options):
+        output_tsv = Path(options["output_tsv"])
+        report_rows = []
+        changed_count = 0
+        unresolved_count = 0
+
+        runs = (
+            Run.objects.filter(experiment_type=Run.ExperimentTypes.UNKNOWN)
+            .select_related("study", "study__ena_study")
+            .prefetch_related("analyses", "assemblies")
+        )
+        total_count = runs.count()
+        logger.info(f"Checking {total_count} UNKNOWN run experiment types")
+
+        for run in runs:
+            previous_experiment_type = run.experiment_type
+            reason = self.determine_experiment_type(run)
+            run.refresh_from_db()
+
+            if run.experiment_type != previous_experiment_type:
+                changed_count += 1
+                self.inherit_changed_run_experiment_type(run)
+                logger.info(
+                    f"Changed run {run.first_accession} from {previous_experiment_type} to {run.experiment_type} using {reason}"
+                )
+                report_rows.append(
+                    self.report_row(run, previous_experiment_type, "changed", reason)
+                )
+            elif run.experiment_type == Run.ExperimentTypes.UNKNOWN:
+                unresolved_count += 1
+                logger.warning(
+                    "Could not determine experiment type for run %s",
+                    run.first_accession,
+                )
+                report_rows.append(
+                    self.report_row(run, previous_experiment_type, "unresolved", reason)
+                )
+
+        self.write_report(output_tsv, report_rows)
+        logger.info(
+            "Finished checking UNKNOWN run experiment types: %s changed, %s unresolved, %s reported",
+            changed_count,
+            unresolved_count,
+            len(report_rows),
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Checked {total_count} UNKNOWN runs; changed {changed_count}; "
+                f"unresolved {unresolved_count}; wrote {output_tsv}"
+            )
+        )
+
+    def determine_experiment_type(self, run: Run) -> str:
+        # if the UNKNOWN type run has analyses with known (curated) types, use those
+        analysis_experiment_types = set(
+            run.analyses.exclude(
+                experiment_type__in=[None, "", Analysis.ExperimentTypes.UNKNOWN]
+            ).values_list("experiment_type", flat=True)
+        )
+
+        if len(analysis_experiment_types) == 1:
+            run.experiment_type = next(iter(analysis_experiment_types))
+            run.save()
+            return "analysis_experiment_type"
+
+        # ... unless they conflict with each other
+        if len(analysis_experiment_types) > 1:
+            logger.error(
+                "Run %s has analyses with conflicting experiment types: %s",
+                run.first_accession,
+                ", ".join(sorted(analysis_experiment_types)),
+            )
+            return "conflicting_analysis_experiment_types"
+
+        # if the run has an assembly, assume it was metagenomic
+        if run.assemblies.exists():
+            run.experiment_type = Run.ExperimentTypes.METAGENOMIC
+            run.save()
+            return "assembly_attached"
+
+        # otherwise use the default handling of ENA policies...
+        # this will still leave some UNKNOWN because we don't know the context in which runs were being fectched,
+        # e.g. if we were in an "amplicon analysis flow" we'd have assumed/ unknown things are probably amplicon
+        metadata = run.metadata_preferring_inferred
+        run.set_experiment_type_by_metadata(
+            ena_library_strategy=metadata.get(Run.CommonMetadataKeys.LIBRARY_STRATEGY)
+            or "",
+            ena_library_source=metadata.get(Run.CommonMetadataKeys.LIBRARY_SOURCE)
+            or "",
+            ena_scientific_name=metadata.get(Run.CommonMetadataKeys.SCIENTIFIC_NAME)
+            or "",
+            library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+            library_source_policy=ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+        )
+        return "ena_metadata"
+
+    def inherit_changed_run_experiment_type(self, run: Run) -> None:
+        for analysis in run.analyses.filter(
+            experiment_type=Analysis.ExperimentTypes.UNKNOWN
+        ):
+            analysis.inherit_experiment_type()
+
+    def report_row(
+        self, run: Run, previous_experiment_type: str, status: str, reason: str
+    ) -> dict[str, str]:
+        metadata = run.metadata_preferring_inferred
+        return {
+            "run_accession": run.first_accession or "",
+            "study_accession": (
+                run.study.ena_study.accession if run.study.ena_study else ""
+            ),
+            "analysis_accessions": ",".join(
+                run.analyses.order_by("accession").values_list("accession", flat=True)
+            ),
+            "library_strategy": metadata.get(Run.CommonMetadataKeys.LIBRARY_STRATEGY)
+            or "",
+            "library_source": metadata.get(Run.CommonMetadataKeys.LIBRARY_SOURCE) or "",
+            "scientific_name": metadata.get(Run.CommonMetadataKeys.SCIENTIFIC_NAME)
+            or "",
+            "previous_experiment_type": previous_experiment_type or "",
+            "new_experiment_type": run.experiment_type or "",
+            "status": status,
+            "reason": reason,
+        }
+
+    def write_report(self, output_tsv: Path, report_rows: list[dict[str, str]]) -> None:
+        output_tsv.parent.mkdir(parents=True, exist_ok=True)
+        with output_tsv.open("w", newline="") as report_file:
+            writer = csv.DictWriter(
+                report_file, fieldnames=self.report_headers, delimiter="\t"
+            )
+            writer.writeheader()
+            writer.writerows(report_rows)

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -43,6 +43,12 @@ from workflows.ena_utils.ena_accession_matching import (
     INSDC_BIOSAMPLE_ACCESSION_REGEX,
     INSDC_STUDY_ACCESSION_REGEX,
 )
+from workflows.ena_utils.ena_policies import (
+    COMMONLY_INCORRECT_LIBRARY_SOURCE,
+    METAGENOME_SCIENTIFIC_NAME,
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
+)
 from workflows.ena_utils.read_run import ENAReadRunFields
 from workflows.ena_utils.sample import ENASampleFields
 
@@ -376,29 +382,79 @@ class Run(
         return latest_analysis.status
 
     def set_experiment_type_by_metadata(
-        self, ena_library_strategy: str, ena_library_source: str
+        self,
+        ena_library_strategy: str,
+        ena_library_source: str,
+        ena_scientific_name: str = "",
+        library_strategy_policy: ENALibraryStrategyPolicy = ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+        library_source_policy: ENALibrarySourcePolicy = ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+        expected_experiment_type: Run.ExperimentTypes | None = None,
     ):
+        """
+        Sets the experiment type based on provided metadata, with consideration for
+        library strategy and source policies. This function assigns a corresponding
+        experiment type considering ENA metadata and policies for overriding and
+        correcting library sources or strategies.
+
+        :param ena_library_strategy: The ENA library strategy provided in the metadata.
+        :param ena_library_source: The ENA library source provided in the metadata.
+        :param ena_scientific_name: The scientific name associated with the data, which may e.g. include "metagenome".
+        :param library_strategy_policy: Policy for how to handle ENA library strategy
+            data. The default behaviour is that no overriding of ENA metadata will happen.
+        :param library_source_policy: Policy governing how to interpret or override
+            the ENA library source data. The Default behaviour overrides genomic sources
+            in cases involving metagenomic scientific names.
+        :param expected_experiment_type: The expected experiment type to directly
+            override metadata-based determination when the library strategy policy
+            allows overriding.
+        :return: None
+        """
         ALLOWED_WHOLE_GENOME_LIBRARY_STRATEGIES = ["wgs", "wga"]
         ALLOWED_AMPLICON_LIBRARY_STRATEGIES = ["amplicon"]
 
-        if ena_library_strategy.lower() == "rna-seq" and (
-            ena_library_source.lower() == "metagenomic"
-            or ena_library_source.lower() == "metatranscriptomic"
+        ena_library_source = ena_library_source.upper()
+        ena_library_strategy = ena_library_strategy.lower()
+        ena_scientific_name = ena_scientific_name.lower()
+
+        is_metagenomic_source = ena_library_source == "METAGENOMIC"
+        is_metatranscriptomic_source = ena_library_source == "METATRANSCRIPTOMIC"
+
+        if library_source_policy == ENALibrarySourcePolicy.OVERRIDE_ALL_TO_METAGENOMIC:
+            is_metagenomic_source = True
+        elif (
+            library_source_policy
+            == ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME
+            and ena_library_source in COMMONLY_INCORRECT_LIBRARY_SOURCE
+        ):
+            if METAGENOME_SCIENTIFIC_NAME in ena_scientific_name:
+                is_metagenomic_source = True
+
+        if library_strategy_policy == ENALibraryStrategyPolicy.OVERRIDE_ALL:
+            if expected_experiment_type is None:
+                raise ValueError(
+                    "expected_experiment_type is required when library_strategy_policy is OVERRIDE_ALL"
+                )
+            self.experiment_type = expected_experiment_type
+            self.save()
+            return
+
+        if ena_library_strategy == "rna-seq" and (
+            is_metagenomic_source or is_metatranscriptomic_source
         ):
             self.experiment_type = Run.ExperimentTypes.METATRANSCRIPTOMIC
         elif (
-            ena_library_strategy.lower() in ALLOWED_WHOLE_GENOME_LIBRARY_STRATEGIES
-            and ena_library_source.lower() == "metatranscriptomic"
+            ena_library_strategy in ALLOWED_WHOLE_GENOME_LIBRARY_STRATEGIES
+            and is_metatranscriptomic_source
         ):
             self.experiment_type = Run.ExperimentTypes.METATRANSCRIPTOMIC
         elif (
-            ena_library_strategy.lower() in ALLOWED_WHOLE_GENOME_LIBRARY_STRATEGIES
-            and ena_library_source.lower() == "metagenomic"
+            ena_library_strategy in ALLOWED_WHOLE_GENOME_LIBRARY_STRATEGIES
+            and is_metagenomic_source
         ):
             self.experiment_type = Run.ExperimentTypes.METAGENOMIC
         elif (
-            ena_library_strategy.lower() in ALLOWED_AMPLICON_LIBRARY_STRATEGIES
-            and ena_library_source.lower() == "metagenomic"
+            ena_library_strategy in ALLOWED_AMPLICON_LIBRARY_STRATEGIES
+            and is_metagenomic_source
         ):
             self.experiment_type = Run.ExperimentTypes.AMPLICON
         else:

--- a/analyses/tests/test_determine_unknown_run_experiment_types.py
+++ b/analyses/tests/test_determine_unknown_run_experiment_types.py
@@ -1,0 +1,195 @@
+import csv
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+
+from analyses.models import Analysis, Assembly, Run, Sample, Study
+from ena.models import Sample as ENASample
+from ena.models import Study as ENAStudy
+
+
+def create_unknown_run(
+    run_accession: str,
+    *,
+    library_strategy: str = "",
+    library_source: str = "",
+    scientific_name: str = "",
+) -> Run:
+    ena_study = ENAStudy.objects.create(accession=f"ERP{run_accession[-6:]}")
+    study = Study.objects.create(ena_study=ena_study, title=f"Study {run_accession}")
+    ena_sample = ENASample.objects.create(
+        accession=f"ERS{run_accession[-6:]}", study=ena_study
+    )
+    sample = Sample.objects.create(ena_study=ena_study, ena_sample=ena_sample)
+    run = Run.objects.create(
+        study=study,
+        ena_study=ena_study,
+        sample=sample,
+        ena_accessions=[run_accession],
+        experiment_type=Run.ExperimentTypes.UNKNOWN,
+        metadata={
+            Run.CommonMetadataKeys.LIBRARY_STRATEGY: library_strategy,
+            Run.CommonMetadataKeys.LIBRARY_SOURCE: library_source,
+            Run.CommonMetadataKeys.SCIENTIFIC_NAME: scientific_name,
+        },
+    )
+    return run
+
+
+def create_analysis(run: Run, experiment_type: str) -> Analysis:
+    return Analysis.objects.create(
+        study=run.study,
+        ena_study=run.ena_study,
+        sample=run.sample,
+        run=run,
+        experiment_type=experiment_type,
+    )
+
+
+def run_command(output_tsv: Path):
+    call_command("determine_unknown_run_experiment_types", output_tsv=str(output_tsv))
+    with output_tsv.open() as report_file:
+        return list(csv.DictReader(report_file, delimiter="\t"))
+
+
+@pytest.mark.django_db
+def test_command_sets_run_type_from_existing_analysis_and_inherits_to_unknown_analyses(
+    tmp_path,
+):
+    run = create_unknown_run("ERR000001")
+    typed_analysis = create_analysis(run, Analysis.ExperimentTypes.AMPLICON)
+    unknown_analysis = create_analysis(run, Analysis.ExperimentTypes.UNKNOWN)
+
+    rows = run_command(tmp_path / "report.tsv")
+
+    run.refresh_from_db()
+    typed_analysis.refresh_from_db()
+    unknown_analysis.refresh_from_db()
+
+    assert run.experiment_type == Run.ExperimentTypes.AMPLICON
+    assert typed_analysis.experiment_type == Analysis.ExperimentTypes.AMPLICON
+    assert unknown_analysis.experiment_type == Analysis.ExperimentTypes.AMPLICON
+    assert rows[0]["run_accession"] == "ERR000001"
+    assert rows[0]["status"] == "changed"
+    assert rows[0]["reason"] == "analysis_experiment_type"
+
+
+@pytest.mark.django_db
+def test_command_logs_error_for_conflicting_analysis_types_and_leaves_run_unknown(
+    tmp_path, caplog
+):
+    run = create_unknown_run("ERR000002")
+    create_analysis(run, Analysis.ExperimentTypes.AMPLICON)
+    create_analysis(run, Analysis.ExperimentTypes.METAGENOMIC)
+
+    rows = run_command(tmp_path / "report.tsv")
+
+    run.refresh_from_db()
+    assert run.experiment_type == Run.ExperimentTypes.UNKNOWN
+    assert "conflicting experiment types" in caplog.text
+    assert "Could not determine experiment type for run ERR000002" in caplog.text
+    assert rows[0]["status"] == "unresolved"
+    assert rows[0]["reason"] == "conflicting_analysis_experiment_types"
+
+
+@pytest.mark.django_db
+def test_command_sets_assembly_attached_run_to_metagenomic(tmp_path):
+    run = create_unknown_run("ERR000003")
+    assembly = Assembly.objects.create(ena_study=run.ena_study, reads_study=run.study)
+    assembly.runs.add(run)
+    analysis = create_analysis(run, Analysis.ExperimentTypes.UNKNOWN)
+
+    rows = run_command(tmp_path / "report.tsv")
+
+    run.refresh_from_db()
+    analysis.refresh_from_db()
+    assert run.experiment_type == Run.ExperimentTypes.METAGENOMIC
+    assert analysis.experiment_type == Analysis.ExperimentTypes.METAGENOMIC
+    assert rows[0]["reason"] == "assembly_attached"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    (
+        "run_accession",
+        "library_strategy",
+        "library_source",
+        "scientific_name",
+        "expected_type",
+    ),
+    [
+        (
+            "ERR000004",
+            "WGS",
+            "METAGENOMIC",
+            "marine metagenome",
+            Run.ExperimentTypes.METAGENOMIC,
+        ),
+        (
+            "ERR000005",
+            "AMPLICON",
+            "METAGENOMIC",
+            "marine metagenome",
+            Run.ExperimentTypes.AMPLICON,
+        ),
+        (
+            "ERR000006",
+            "AMPLICON",
+            "GENOMIC",
+            "marine metagenome",
+            Run.ExperimentTypes.AMPLICON,
+        ),
+    ],
+)
+def test_command_sets_raw_read_and_amplicon_run_types_from_metadata(
+    tmp_path,
+    run_accession,
+    library_strategy,
+    library_source,
+    scientific_name,
+    expected_type,
+):
+    run = create_unknown_run(
+        run_accession,
+        library_strategy=library_strategy,
+        library_source=library_source,
+        scientific_name=scientific_name,
+    )
+
+    rows = run_command(tmp_path / f"{run_accession}.tsv")
+
+    run.refresh_from_db()
+    assert run.experiment_type == expected_type
+    assert rows[0]["status"] == "changed"
+    assert rows[0]["reason"] == "ena_metadata"
+    assert rows[0]["library_source"] == library_source
+
+
+@pytest.mark.django_db
+def test_command_warns_and_reports_run_that_remains_unknown(tmp_path, caplog):
+    run = create_unknown_run(
+        "ERR000007",
+        library_strategy="AMPLICON",
+        library_source="GENOMIC",
+        scientific_name="Homo sapiens",
+    )
+
+    rows = run_command(tmp_path / "report.tsv")
+
+    run.refresh_from_db()
+    assert run.experiment_type == Run.ExperimentTypes.UNKNOWN
+    assert "Could not determine experiment type for run ERR000007" in caplog.text
+    assert rows[0]["status"] == "unresolved"
+    assert rows[0]["reason"] == "ena_metadata"
+
+
+@pytest.mark.django_db
+def test_command_ignores_runs_that_are_not_unknown(tmp_path):
+    run = create_unknown_run("ERR000008")
+    run.experiment_type = Run.ExperimentTypes.METAGENOMIC
+    run.save()
+
+    rows = run_command(tmp_path / "report.tsv")
+
+    assert rows == []

--- a/analyses/tests/test_models.py
+++ b/analyses/tests/test_models.py
@@ -12,9 +12,15 @@ from analyses.models import (
     Biome,
     ComputeResourceHeuristic,
     Run,
+    Sample,
     Study,
 )
+from ena.models import Sample as ENASample
 from ena.models import Study as ENAStudy
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
+)
 
 
 def create_analysis(is_private=False):
@@ -26,6 +32,62 @@ def create_analysis(is_private=False):
         sample=run.sample,
         is_private=is_private,
     )
+
+
+@pytest.mark.django_db
+def test_set_experiment_type_by_metadata():
+    ena_study = ENAStudy.objects.create(accession="ERP123")
+    study = Study.objects.create(ena_study=ena_study, title="Project 1")
+    ena_sample = ENASample.objects.create(accession="ERS123", study=ena_study)
+    sample = Sample.objects.create(ena_study=ena_study, ena_sample=ena_sample)
+    run = Run.objects.create(study=study, ena_study=ena_study, sample=sample)
+
+    # Normal Case: Metagenomic + WGS
+    run.set_experiment_type_by_metadata("WGS", "METAGENOMIC")
+    assert run.experiment_type == Run.ExperimentTypes.METAGENOMIC
+
+    # Case from issue: Metagenome scientific name + GENOMIC + AMPLICON
+    run.set_experiment_type_by_metadata(
+        "AMPLICON", "GENOMIC", ena_scientific_name="marine metagenome"
+    )
+    assert run.experiment_type == Run.ExperimentTypes.AMPLICON
+
+    # Case from issue: Metagenome scientific name + GENOMIC + WGS
+    run.set_experiment_type_by_metadata(
+        "WGS", "GENOMIC", ena_scientific_name="marine metagenome"
+    )
+    assert run.experiment_type == Run.ExperimentTypes.METAGENOMIC
+
+    # Unknown case: GENOMIC + AMPLICON (without metagenome scientific name)
+    run.set_experiment_type_by_metadata(
+        "AMPLICON", "GENOMIC", ena_scientific_name="Homo sapiens"
+    )
+    assert run.experiment_type == Run.ExperimentTypes.UNKNOWN
+
+    # ONLY_IF_METAGENOMIC_IN_ENA policy
+    run.set_experiment_type_by_metadata(
+        "AMPLICON",
+        "GENOMIC",
+        ena_scientific_name="marine metagenome",
+        library_source_policy=ENALibrarySourcePolicy.ONLY_IF_METAGENOMIC_IN_ENA,
+    )
+    assert run.experiment_type == Run.ExperimentTypes.UNKNOWN
+
+    # OVERRIDE_ALL strategy policy persists the caller-provided expected experiment type
+    run.set_experiment_type_by_metadata(
+        "OTHER",
+        "GENOMIC",
+        library_strategy_policy=ENALibraryStrategyPolicy.OVERRIDE_ALL,
+        expected_experiment_type=Run.ExperimentTypes.AMPLICON,
+    )
+    assert run.experiment_type == Run.ExperimentTypes.AMPLICON
+
+    with pytest.raises(ValueError):
+        run.set_experiment_type_by_metadata(
+            "OTHER",
+            "GENOMIC",
+            library_strategy_policy=ENALibraryStrategyPolicy.OVERRIDE_ALL,
+        )
 
 
 @pytest.mark.django_db(transaction=True, reset_sequences=True)

--- a/emgapiv2/config.py
+++ b/emgapiv2/config.py
@@ -253,6 +253,7 @@ class ENAConfig(BaseModel):
     ]
     portal_search_api_max_retries: int = 4
     portal_search_api_retry_delay_seconds: int = 15
+    portal_max_readruns_to_fetch: int = 10000
     browser_view_url_prefix: AnyHttpUrl = "https://www.ebi.ac.uk/ena/browser/view"
     # TODO: migrate to the ENA Handler
     study_metadata_fields: list[str] = [

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -24,6 +24,7 @@ from workflows.ena_utils.ena_policies import (
     COMMONLY_INCORRECT_LIBRARY_SOURCE,
     METAGENOME_SCIENTIFIC_NAME,
     PAIRED_END_LIBRARY_LAYOUT,
+    PRIMARY_METAGENOME_ASSEMBLY_TYPE,
     ENALibrarySourcePolicy,
     ENALibraryStrategyPolicy,
 )
@@ -31,9 +32,6 @@ from workflows.ena_utils.read_run import ENAReadRunFields, ENAReadRunQuery
 from workflows.ena_utils.requestors import ENAAPIRequest, ENAAvailabilityException
 from workflows.ena_utils.sample import ENASampleFields, ENASampleQuery
 from workflows.ena_utils.study import ENAStudyFields, ENAStudyQuery
-
-
-PRIMARY_METAGENOME_ASSEMBLY_TYPE: str = '"primary metagenome"'
 
 EMG_CONFIG = settings.EMG_CONFIG
 

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -12,7 +12,6 @@ from prefect.tasks import task_input_hash
 import analyses.models
 import ena.models
 from emgapiv2.dict_utils import some
-from emgapiv2.enum_utils import FutureStrEnum
 from workflows.ena_utils.abstract import ENAPortalResultType
 from workflows.ena_utils.analysis import ENAAnalysisFields, ENAAnalysisQuery
 from workflows.ena_utils.ena_accession_matching import (
@@ -20,15 +19,20 @@ from workflows.ena_utils.ena_accession_matching import (
     extract_study_accession_from_study_title,
 )
 from workflows.ena_utils.ena_auth import dcc_auth
+from workflows.ena_utils.ena_policies import (
+    ALLOWED_LIBRARY_SOURCE,
+    COMMONLY_INCORRECT_LIBRARY_SOURCE,
+    METAGENOME_SCIENTIFIC_NAME,
+    PAIRED_END_LIBRARY_LAYOUT,
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
+)
 from workflows.ena_utils.read_run import ENAReadRunFields, ENAReadRunQuery
 from workflows.ena_utils.requestors import ENAAPIRequest, ENAAvailabilityException
 from workflows.ena_utils.sample import ENASampleFields, ENASampleQuery
 from workflows.ena_utils.study import ENAStudyFields, ENAStudyQuery
 
-ALLOWED_LIBRARY_SOURCE: list = ["METAGENOMIC", "METATRANSCRIPTOMIC"]
-SINGLE_END_LIBRARY_LAYOUT: str = "SINGLE"
-PAIRED_END_LIBRARY_LAYOUT: str = "PAIRED"
-METAGENOME_SCIENTIFIC_NAME: str = "metagenome"
+
 PRIMARY_METAGENOME_ASSEMBLY_TYPE: str = '"primary metagenome"'
 
 EMG_CONFIG = settings.EMG_CONFIG
@@ -38,16 +42,6 @@ RETRY_DELAY = EMG_CONFIG.ena.portal_search_api_retry_delay_seconds
 
 
 base_logger = logging.getLogger(__name__)
-
-
-class ENALibraryStrategyPolicy(FutureStrEnum):
-    """
-    Each policy determines a trust vs. override level for the library strategy metadata in ENA.
-    """
-
-    ONLY_IF_CORRECT_IN_ENA = "only_if_correct_in_ena"
-    ASSUME_OTHER_ALSO_MATCHES = "assume_other_also_matches"
-    OVERRIDE_ALL = "override_all"
 
 
 def library_strategy_policy_to_filter(
@@ -197,8 +191,29 @@ def check_reads_fastq(
 
 
 def _make_samples_and_run(
-    run_or_assembly_response: dict, study: analyses.models.Study
+    run_or_assembly_response: dict,
+    study: analyses.models.Study,
+    library_strategy_policy: ENALibraryStrategyPolicy = ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+    library_source_policy: ENALibrarySourcePolicy = ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+    expected_experiment_type: analyses.models.Run.ExperimentTypes | None = None,
 ) -> tuple[ena.models.Sample, analyses.models.Sample, analyses.models.Run]:
+    """
+    Generate and update samples and runs for given study and ENA data.
+
+    This function updates or creates ENA and MGnify sample records as well as
+    run records using the provided ENA data and study information. Metadata
+    for samples and runs is extracted and synchronized accordingly. It also
+    handles library strategy and source policies to determine experiment
+    types. If an ENA sample is newly created, it fetches complete metadata
+    for the sample from the ENA API.
+
+    :param run_or_assembly_response: A dictionary containing metadata from ENA about a run or assembly.
+    :param study: A Study object representing the context in which the samples and runs are created or updated.
+    :param library_strategy_policy: Policy dictating how to handle library strategies that may be incorrect in ENA
+    :param library_source_policy: Policy determining how library source from ENA is interpreted or overridden
+    :param expected_experiment_type: Optional predefined expected experiment type, used if the policies dictate it should be overridden
+    :return: A tuple with three components - (ENA sample, MGnify sample, Run).
+    """
     _ = ENAReadRunFields  # fields used here are also present on ENAAnalysisFields
 
     ena_sample, ena_sample_was_created = ena.models.Sample.objects.update_or_create(
@@ -263,6 +278,10 @@ def _make_samples_and_run(
     run.set_experiment_type_by_metadata(
         run_or_assembly_response.get(_.LIBRARY_STRATEGY, ""),
         run_or_assembly_response.get(_.LIBRARY_SOURCE, ""),
+        run_or_assembly_response.get(_.SCIENTIFIC_NAME, ""),
+        library_strategy_policy=library_strategy_policy,
+        library_source_policy=library_source_policy,
+        expected_experiment_type=expected_experiment_type,
     )
 
     if ena_sample_was_created:
@@ -284,8 +303,11 @@ def _make_samples_and_run(
 def get_study_readruns_from_ena(
     accession: str,
     limit: int = 20,
-    filter_library_strategy: list[str] = None,
+    filter_library_strategy: list[str] | None = None,
     raise_on_empty: bool = True,
+    library_strategy_policy: ENALibraryStrategyPolicy = ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+    library_source_policy: ENALibrarySourcePolicy = ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+    expected_experiment_type: analyses.models.Run.ExperimentTypes | None = None,
 ) -> List[str]:
     """
     Retrieve a list of read_runs from the ENA Portal API, for a given study.
@@ -347,12 +369,21 @@ def get_study_readruns_from_ena(
     run_accessions = []
     for read_run in portal_read_runs:
         # check scientific name and metagenome source
-        if (
-            METAGENOME_SCIENTIFIC_NAME not in read_run[_.SCIENTIFIC_NAME]
-            and read_run[_.LIBRARY_SOURCE] not in ALLOWED_LIBRARY_SOURCE
-        ):
+        if library_source_policy == ENALibrarySourcePolicy.OVERRIDE_ALL_TO_METAGENOMIC:
+            library_source_is_valid_by_policy = True
+        elif library_source_policy == ENALibrarySourcePolicy.ONLY_IF_METAGENOMIC_IN_ENA:
+            library_source_is_valid_by_policy = (
+                read_run[_.LIBRARY_SOURCE] in ALLOWED_LIBRARY_SOURCE
+            )
+        else:  # OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME
+            library_source_is_valid_by_policy = (
+                METAGENOME_SCIENTIFIC_NAME in read_run[_.SCIENTIFIC_NAME].lower()
+                and read_run[_.LIBRARY_SOURCE] in COMMONLY_INCORRECT_LIBRARY_SOURCE
+            ) or read_run[_.LIBRARY_SOURCE] in ALLOWED_LIBRARY_SOURCE
+
+        if not library_source_is_valid_by_policy:
             logger.warning(
-                f"Run {read_run['run_accession']} is not in metagenome taxa and not in allowed library_sources. "
+                f"Run {read_run['run_accession']} is not in metagenome taxa and not in allowed library_sources (policy: {library_source_policy}). "
                 f"No further processing for that run."
             )
             continue
@@ -371,7 +402,13 @@ def get_study_readruns_from_ena(
 
         logger.info(f"Creating objects for {read_run[_.RUN_ACCESSION]}")
 
-        __, __, run = _make_samples_and_run(read_run, mgys_study)
+        __, __, run = _make_samples_and_run(
+            read_run,
+            mgys_study,
+            library_strategy_policy=library_strategy_policy,
+            library_source_policy=library_source_policy,
+            expected_experiment_type=expected_experiment_type,
+        )
         run.metadata[analyses.models.Run.CommonMetadataKeys.FASTQ_FTPS] = (
             fastq_ftp_reads
         )
@@ -482,7 +519,13 @@ def sync_privacy_state_of_ena_study_and_derived_objects(
     cache_key_fn=task_input_hash,
     task_run_name="Get study assemblies from ENA: {accession}",
 )
-def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
+def get_study_assemblies_from_ena(
+    accession: str,
+    limit: int = 10,
+    library_strategy_policy: ENALibraryStrategyPolicy = ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+    library_source_policy: ENALibrarySourcePolicy = ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+    expected_experiment_type: analyses.models.Run.ExperimentTypes | None = None,
+) -> list[str]:
     """
     Fetches a list of assemblies from the European Nucleotide Archive (ENA) for a given study accession.
 
@@ -540,7 +583,12 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
 
     # read-runs may exist in the same study as the assemblies
     portal_runs = get_study_readruns_from_ena(
-        accession=accession, limit=limit, raise_on_empty=False
+        accession=accession,
+        limit=limit,
+        raise_on_empty=False,
+        library_strategy_policy=library_strategy_policy,
+        library_source_policy=library_source_policy,
+        expected_experiment_type=expected_experiment_type,
     )
 
     if study.assemblies_assembly.exists():
@@ -578,6 +626,9 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
         get_study_readruns_from_ena(
             accession=reads_study.first_accession,
             limit=limit,
+            library_strategy_policy=library_strategy_policy,
+            library_source_policy=library_source_policy,
+            expected_experiment_type=expected_experiment_type,
         )
 
     assemblies: list[str] = []
@@ -591,7 +642,13 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
         except analyses.models.Sample.DoesNotExist:
             # make sample based on metadata available from ENA assembly
             logger.info(f"Creating sample for {assembly_data[_.SAMPLE_ACCESSION]}")
-            __, mgnify_sample, run = _make_samples_and_run(assembly_data, study)
+            __, mgnify_sample, run = _make_samples_and_run(
+                assembly_data,
+                study,
+                library_strategy_policy=library_strategy_policy,
+                library_source_policy=library_source_policy,
+                expected_experiment_type=expected_experiment_type,
+            )
         else:
             run = mgnify_sample.runs.first()  # TODO: coassemblies? replicates?
 

--- a/workflows/ena_utils/ena_policies.py
+++ b/workflows/ena_utils/ena_policies.py
@@ -1,0 +1,29 @@
+from emgapiv2.enum_utils import FutureStrEnum
+
+ALLOWED_LIBRARY_SOURCE: list = ["METAGENOMIC", "METATRANSCRIPTOMIC"]
+COMMONLY_INCORRECT_LIBRARY_SOURCE: list = ["GENOMIC", "OTHER"]
+SINGLE_END_LIBRARY_LAYOUT: str = "SINGLE"
+PAIRED_END_LIBRARY_LAYOUT: str = "PAIRED"
+METAGENOME_SCIENTIFIC_NAME: str = "metagenome"
+
+
+class ENALibraryStrategyPolicy(FutureStrEnum):
+    """
+    Each policy determines a trust vs. override level for the library strategy metadata in ENA.
+    """
+
+    ONLY_IF_CORRECT_IN_ENA = "only_if_correct_in_ena"
+    ASSUME_OTHER_ALSO_MATCHES = "assume_other_also_matches"
+    OVERRIDE_ALL = "override_all"
+
+
+class ENALibrarySourcePolicy(FutureStrEnum):
+    """
+    Each policy determines how to handle the library source metadata in ENA.
+    """
+
+    ONLY_IF_METAGENOMIC_IN_ENA = "only_if_metagenomic_in_ena"
+    OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME = (
+        "override_genomic_if_metagenomic_scientific_name"
+    )
+    OVERRIDE_ALL_TO_METAGENOMIC = "override_all_to_metagenomic"

--- a/workflows/ena_utils/ena_policies.py
+++ b/workflows/ena_utils/ena_policies.py
@@ -5,6 +5,7 @@ COMMONLY_INCORRECT_LIBRARY_SOURCE: list = ["GENOMIC", "OTHER"]
 SINGLE_END_LIBRARY_LAYOUT: str = "SINGLE"
 PAIRED_END_LIBRARY_LAYOUT: str = "PAIRED"
 METAGENOME_SCIENTIFIC_NAME: str = "metagenome"
+PRIMARY_METAGENOME_ASSEMBLY_TYPE: str = '"primary metagenome"'
 
 
 class ENALibraryStrategyPolicy(FutureStrEnum):

--- a/workflows/flows/analysis/assembly/flows/analysis_assembly_study.py
+++ b/workflows/flows/analysis/assembly/flows/analysis_assembly_study.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from textwrap import dedent as _
-from typing import List, Optional
+from typing import List, Optional, Type
 
 from prefect import get_run_logger, suspend_flow_run
 from prefect.deployments import run_deployment
@@ -15,6 +15,10 @@ import workflows.models
 from workflows.ena_utils.ena_api_requests import (
     get_study_assemblies_from_ena,
     get_study_from_ena,
+)
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
 )
 from workflows.ena_utils.webin_owner_utils import validate_and_set_webin_owner
 from workflows.flows.analysis.assembly.tasks.create_analyses_for_assemblies import (
@@ -73,6 +77,7 @@ def analysis_assembly_study(
     assemblies_accessions: list[str] = get_study_assemblies_from_ena(
         ena_study.accession,
         limit=10000,  # TODO: this should be a config value
+        expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,
     )
     logger.info(f"Returned {len(assemblies_accessions)} assemblies from ENA portal API")
 
@@ -86,9 +91,17 @@ def analysis_assembly_study(
 
         class AnalyseStudyInput(RunInput):
             biome: BiomeChoices
-            watchers: Optional[List[UserChoices]] = Field(
+            watchers: Optional[List[Type[UserChoices]]] = Field(
                 None,
                 description="Admin users watching this study will get status notifications.",
+            )
+            library_strategy_policy: ENALibraryStrategyPolicy = Field(
+                ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                description="Optionally treat assemblies with incorrect library strategy metadata as raw-reads.",
+            )
+            library_source_policy: ENALibrarySourcePolicy = Field(
+                ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+                description="How to handle the library source metadata (e.g. if it is GENOMIC instead of METAGENOMIC).",
             )
             webin_owner: Optional[str] = Field(
                 None,
@@ -126,6 +139,24 @@ def analysis_assembly_study(
 
         validate_and_set_webin_owner(ena_study, analyse_study_input.webin_owner)
         mgnify_study.refresh_from_db()
+
+        if (
+            analyse_study_input.library_strategy_policy
+            != ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
+            or analyse_study_input.library_source_policy
+            != ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME
+        ):
+            assemblies_accessions = get_study_assemblies_from_ena(
+                ena_study.accession,
+                limit=10000,
+                library_strategy_policy=analyse_study_input.library_strategy_policy,
+                library_source_policy=analyse_study_input.library_source_policy,
+                expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,
+            )
+            logger.info(
+                f"Using policies strategy:{analyse_study_input.library_strategy_policy} source:{analyse_study_input.library_source_policy}, "
+                f"now returned {len(assemblies_accessions)} assemblies from ENA portal API."
+            )
     else:
         logger.info(
             f"Biome {mgnify_study.biome} was already set for this study. If a change is needed, do so in the DB Admin Panel."

--- a/workflows/flows/analysis/assembly/flows/analysis_assembly_study.py
+++ b/workflows/flows/analysis/assembly/flows/analysis_assembly_study.py
@@ -76,7 +76,7 @@ def analysis_assembly_study(
     # Get assemble-able runs
     assemblies_accessions: list[str] = get_study_assemblies_from_ena(
         ena_study.accession,
-        limit=10000,  # TODO: this should be a config value
+        limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
         expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,
     )
     logger.info(f"Returned {len(assemblies_accessions)} assemblies from ENA portal API")
@@ -148,7 +148,7 @@ def analysis_assembly_study(
         ):
             assemblies_accessions = get_study_assemblies_from_ena(
                 ena_study.accession,
-                limit=10000,
+                limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
                 library_strategy_policy=analyse_study_input.library_strategy_policy,
                 library_source_policy=analyse_study_input.library_source_policy,
                 expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,

--- a/workflows/flows/analysis_amplicon_study.py
+++ b/workflows/flows/analysis_amplicon_study.py
@@ -97,7 +97,7 @@ def analysis_amplicon_study(study_accession: str):
 
     read_runs = get_study_readruns_from_ena(
         ena_study.accession,
-        limit=10000,  # TODO: This should be a parameter or config
+        limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
         raise_on_empty=False,
         filter_library_strategy=library_strategy_policy_to_filter(
             _AMPLICON, policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
@@ -169,7 +169,7 @@ def analysis_amplicon_study(study_accession: str):
     ):
         read_runs = get_study_readruns_from_ena(
             ena_study.accession,
-            limit=10000,
+            limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
             raise_on_empty=True,
             filter_library_strategy=library_strategy_policy_to_filter(
                 _AMPLICON, policy=analyse_study_input.library_strategy_policy

--- a/workflows/flows/analysis_amplicon_study.py
+++ b/workflows/flows/analysis_amplicon_study.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from textwrap import dedent as _
-from typing import List, Optional
+from typing import List, Optional, Type
 
 from prefect import get_run_logger, suspend_flow_run
 from prefect.events import emit_event
@@ -14,10 +14,13 @@ import analyses.base_models.with_experiment_type_models
 import analyses.models
 import ena.models
 from workflows.ena_utils.ena_api_requests import (
-    ENALibraryStrategyPolicy,
     get_study_from_ena,
     get_study_readruns_from_ena,
     library_strategy_policy_to_filter,
+)
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
 )
 from workflows.ena_utils.webin_owner_utils import validate_and_set_webin_owner
 from workflows.flows.analyse_study_tasks.amplicon.run_amplicon_pipeline_via_samplesheet import (
@@ -99,6 +102,7 @@ def analysis_amplicon_study(study_accession: str):
         filter_library_strategy=library_strategy_policy_to_filter(
             _AMPLICON, policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
         ),
+        expected_experiment_type=analyses.models.Run.ExperimentTypes.AMPLICON,
     )
     logger.info(f"Returned {len(read_runs)} run from ENA portal API")
 
@@ -107,13 +111,17 @@ def analysis_amplicon_study(study_accession: str):
 
     class AnalyseStudyInput(RunInput):
         biome: BiomeChoices
-        watchers: Optional[List[UserChoices]] = Field(
+        watchers: Optional[List[Type[UserChoices]]] = Field(
             None,
             description="Admin users watching this study will get status notifications.",
         )
         library_strategy_policy: ENALibraryStrategyPolicy = Field(
             ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
             description="Optionally treat read-runs with incorrect library strategy metadata as amplicon.",
+        )
+        library_source_policy: ENALibrarySourcePolicy = Field(
+            ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+            description="How to handle the library source metadata (e.g. if it is GENOMIC instead of METAGENOMIC).",
         )
         webin_owner: Optional[str] = Field(
             None,
@@ -155,8 +163,9 @@ def analysis_amplicon_study(study_accession: str):
 
     if (
         analyse_study_input.library_strategy_policy
-        and not analyse_study_input.library_strategy_policy
-        == ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
+        != ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
+        or analyse_study_input.library_source_policy
+        != ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME
     ):
         read_runs = get_study_readruns_from_ena(
             ena_study.accession,
@@ -165,9 +174,12 @@ def analysis_amplicon_study(study_accession: str):
             filter_library_strategy=library_strategy_policy_to_filter(
                 _AMPLICON, policy=analyse_study_input.library_strategy_policy
             ),
+            library_strategy_policy=analyse_study_input.library_strategy_policy,
+            library_source_policy=analyse_study_input.library_source_policy,
+            expected_experiment_type=analyses.models.Run.ExperimentTypes.AMPLICON,
         )
         logger.info(
-            f"Using policy {analyse_study_input.library_strategy_policy}, "
+            f"Using policies strategy:{analyse_study_input.library_strategy_policy} source:{analyse_study_input.library_source_policy}, "
             f"now returned {len(read_runs)} run from ENA portal API."
         )
 

--- a/workflows/flows/analysis_rawreads_study.py
+++ b/workflows/flows/analysis_rawreads_study.py
@@ -84,7 +84,7 @@ def analysis_rawreads_study(study_accession: str):
 
     read_runs = get_study_readruns_from_ena(
         ena_study.accession,
-        limit=10000,
+        limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
         raise_on_empty=False,
         filter_library_strategy=library_strategy_policy_to_filter(
             _METAGENOMIC, policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
@@ -157,7 +157,7 @@ def analysis_rawreads_study(study_accession: str):
     ):
         read_runs = get_study_readruns_from_ena(
             ena_study.accession,
-            limit=10000,
+            limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
             raise_on_empty=True,
             filter_library_strategy=library_strategy_policy_to_filter(
                 _METAGENOMIC, policy=analyse_study_input.library_strategy_policy

--- a/workflows/flows/analysis_rawreads_study.py
+++ b/workflows/flows/analysis_rawreads_study.py
@@ -13,10 +13,13 @@ import analyses.base_models.with_experiment_type_models
 import analyses.models
 import ena.models
 from workflows.ena_utils.ena_api_requests import (
-    ENALibraryStrategyPolicy,
     get_study_from_ena,
     get_study_readruns_from_ena,
     library_strategy_policy_to_filter,
+)
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
 )
 from workflows.ena_utils.webin_owner_utils import validate_and_set_webin_owner
 from workflows.flows.analyse_study_tasks.cleanup_pipeline_directories import (
@@ -86,6 +89,7 @@ def analysis_rawreads_study(study_accession: str):
         filter_library_strategy=library_strategy_policy_to_filter(
             _METAGENOMIC, policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
         ),
+        expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,
     )
     logger.info(f"Returned {len(read_runs)} runs from ENA portal API")
 
@@ -101,6 +105,10 @@ def analysis_rawreads_study(study_accession: str):
         library_strategy_policy: ENALibraryStrategyPolicy = Field(
             ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
             description="Optionally treat read-runs with incorrect library strategy metadata as raw-reads.",
+        )
+        library_source_policy: ENALibrarySourcePolicy = Field(
+            ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+            description="How to handle the library source metadata (e.g. if it is GENOMIC instead of METAGENOMIC).",
         )
         functional_analysis: bool = Field(
             False,
@@ -143,8 +151,9 @@ def analysis_rawreads_study(study_accession: str):
 
     if (
         analyse_study_input.library_strategy_policy
-        and not analyse_study_input.library_strategy_policy
-        == ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
+        != ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
+        or analyse_study_input.library_source_policy
+        != ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME
     ):
         read_runs = get_study_readruns_from_ena(
             ena_study.accession,
@@ -153,9 +162,12 @@ def analysis_rawreads_study(study_accession: str):
             filter_library_strategy=library_strategy_policy_to_filter(
                 _METAGENOMIC, policy=analyse_study_input.library_strategy_policy
             ),
+            library_strategy_policy=analyse_study_input.library_strategy_policy,
+            library_source_policy=analyse_study_input.library_source_policy,
+            expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,
         )
         logger.info(
-            f"Using policy {analyse_study_input.library_strategy_policy}, "
+            f"Using policies strategy:{analyse_study_input.library_strategy_policy} source:{analyse_study_input.library_source_policy}, "
             f"now returned {len(read_runs)} run from ENA portal API."
         )
 

--- a/workflows/flows/assemble_study.py
+++ b/workflows/flows/assemble_study.py
@@ -102,7 +102,7 @@ def assemble_study(
 
     read_runs = get_study_readruns_from_ena(
         ena_study.accession,
-        limit=5000,
+        limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
         expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,
     )
     logger.info(f"Have {len(read_runs)} from ENA portal API")
@@ -181,7 +181,7 @@ def assemble_study(
     ):
         read_runs = get_study_readruns_from_ena(
             ena_study.accession,
-            limit=5000,
+            limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
             library_strategy_policy=assemble_study_input.library_strategy_policy,
             library_source_policy=assemble_study_input.library_source_policy,
             expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,

--- a/workflows/flows/assemble_study.py
+++ b/workflows/flows/assemble_study.py
@@ -17,9 +17,12 @@ import analyses.models
 import ena.models
 from emgapiv2.enum_utils import FutureStrEnum
 from workflows.ena_utils.ena_api_requests import (
-    ENALibraryStrategyPolicy,
     get_study_from_ena,
     get_study_readruns_from_ena,
+)
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
 )
 from workflows.ena_utils.webin_owner_utils import validate_and_set_webin_owner
 from workflows.flows.analyse_study_tasks.cleanup_pipeline_directories import (
@@ -100,6 +103,7 @@ def assemble_study(
     read_runs = get_study_readruns_from_ena(
         ena_study.accession,
         limit=5000,
+        expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,
     )
     logger.info(f"Have {len(read_runs)} from ENA portal API")
 
@@ -131,6 +135,10 @@ def assemble_study(
         library_strategy_policy: ENALibraryStrategyPolicy = Field(
             ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
             description="Optionally treat read-runs with incorrect library strategy metadata as assemblable.",
+        )
+        library_source_policy: ENALibrarySourcePolicy = Field(
+            ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
+            description="How to handle the library source metadata (e.g. if it is GENOMIC instead of METAGENOMIC).",
         )
         wait_for_samplesheet_editing: bool = Field(
             False,
@@ -164,6 +172,24 @@ def assemble_study(
 
     validate_and_set_webin_owner(ena_study, assemble_study_input.webin_owner)
     mgnify_study.refresh_from_db()
+
+    if (
+        assemble_study_input.library_strategy_policy
+        != ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA
+        or assemble_study_input.library_source_policy
+        != ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME
+    ):
+        read_runs = get_study_readruns_from_ena(
+            ena_study.accession,
+            limit=5000,
+            library_strategy_policy=assemble_study_input.library_strategy_policy,
+            library_source_policy=assemble_study_input.library_source_policy,
+            expected_experiment_type=analyses.models.Run.ExperimentTypes.METAGENOMIC,
+        )
+        logger.info(
+            f"Using policies strategy:{assemble_study_input.library_strategy_policy} source:{assemble_study_input.library_source_policy}, "
+            f"now returned {len(read_runs)} runs from ENA portal API."
+        )
 
     if assemble_study_input.watchers:
         add_study_watchers(mgnify_study, assemble_study_input.watchers)

--- a/workflows/flows/import_assemblies_from_filesystem_flow.py
+++ b/workflows/flows/import_assemblies_from_filesystem_flow.py
@@ -6,7 +6,7 @@ from pandera.typing import DataFrame
 from prefect import get_run_logger
 from prefect.artifacts import create_table_artifact
 
-import activate_django_first  # noqa
+from activate_django_first import EMG_CONFIG
 
 import analyses.models
 from workflows.data_io_utils.miassembler_utils import (
@@ -434,7 +434,7 @@ def import_assemblies_from_filesystem_flow(
     if fetch_read_runs_from_ena:
         read_runs = get_study_readruns_from_ena(
             reads_mgnify_study.first_accession,
-            limit=500,  # TODO: make this configurable, or to provide the accessions as a parameter
+            limit=EMG_CONFIG.ena.portal_max_readruns_to_fetch,
             raise_on_empty=False,
         )
         logger.info(f"Fetched or refreshed {len(read_runs)} read runs from ENA")

--- a/workflows/tests/test_analysis_amplicon_study_flow.py
+++ b/workflows/tests/test_analysis_amplicon_study_flow.py
@@ -20,7 +20,10 @@ import analyses.models
 from workflows.data_io_utils.file_rules.base_rules import FileRule, GlobRule
 from workflows.data_io_utils.file_rules.common_rules import GlobHasFilesCountRule
 from workflows.data_io_utils.file_rules.nodes import Directory
-from workflows.ena_utils.ena_api_requests import ENALibraryStrategyPolicy
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
+)
 from workflows.flows.analyse_study_tasks.cleanup_pipeline_directories import (
     # delete_study_results_dir,
     delete_study_nextflow_workdir,
@@ -584,6 +587,7 @@ def analysis_study_input_mocker(biome_choices, user_choices):
         webin_owner: Optional[str]
         watchers: List[user_choices]
         library_strategy_policy: ENALibraryStrategyPolicy
+        library_source_policy: ENALibrarySourcePolicy
 
     return MockAnalyseStudyInput
 
@@ -1115,6 +1119,7 @@ def test_prefect_analyse_amplicon_flow(
                 biome=biome_choices["root.engineered"],
                 watchers=[user_choices[admin_user.username]],
                 library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                library_source_policy=ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
                 webin_owner=None,
             )
 
@@ -1649,6 +1654,7 @@ def test_prefect_analyse_amplicon_flow_private_data(
                 biome=biome_choices["root.engineered"],
                 watchers=[user_choices[admin_user.username]],
                 library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                library_source_policy=ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
                 webin_owner="webin-1",
             )
 

--- a/workflows/tests/test_analysis_assembly_study_flow.py
+++ b/workflows/tests/test_analysis_assembly_study_flow.py
@@ -16,6 +16,10 @@ import ena.models
 from analyses.base_models.with_downloads_models import DownloadType
 from analyses.models import Analysis, Study
 from workflows.data_io_utils.filenames import accession_prefix_separated_dir_path
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
+)
 from workflows.flows.analysis.assembly.flows.analysis_assembly_study import (
     analysis_assembly_study,
 )
@@ -103,6 +107,8 @@ def analyse_study_input_mocker(biome_choices, user_choices):
         biome: biome_choices
         watchers: Optional[List[user_choices]] = None
         webin_owner: Optional[str] = None
+        library_strategy_policy: Optional[ENALibraryStrategyPolicy] = None
+        library_source_policy: Optional[ENALibrarySourcePolicy] = None
 
     return MockAnalyseStudyInput
 
@@ -518,6 +524,7 @@ def test_prefect_analyse_assembly_flow(
         url=re.compile(
             f"{re.escape(EMG_CONFIG.ena.portal_search_api)}\\?result=analysis&query=.*{re.escape(assembly_test_scenario.study_accession)}.*"
         ),
+        is_reusable=True,
         json=[
             {
                 "sample_accession": assembly_test_scenario.sample_accession,
@@ -541,6 +548,7 @@ def test_prefect_analyse_assembly_flow(
         url=re.compile(
             f"{re.escape(EMG_CONFIG.ena.portal_search_api)}\\?result=read_run&query=.*{re.escape(assembly_test_scenario.study_accession)}.*"
         ),
+        is_reusable=True,
         json=[
             {
                 "sample_accession": assembly_test_scenario.sample_accession,
@@ -910,6 +918,7 @@ def test_prefect_analyse_assembly_flow_missing_directory(
         url=re.compile(
             f"{re.escape(EMG_CONFIG.ena.portal_search_api)}\\?result=analysis&query=.*{re.escape(scenario.study_accession)}.*"
         ),
+        is_reusable=True,
         json=[
             {
                 "sample_accession": scenario.sample_accession,
@@ -933,6 +942,7 @@ def test_prefect_analyse_assembly_flow_missing_directory(
         url=re.compile(
             f"{re.escape(EMG_CONFIG.ena.portal_search_api)}\\?result=read_run&query=.*{re.escape(scenario.study_accession)}.*"
         ),
+        is_reusable=True,
         json=[
             {
                 "sample_accession": scenario.sample_accession,
@@ -1089,6 +1099,7 @@ def test_prefect_analyse_assembly_flow_invalid_schema(
         url=re.compile(
             f"{re.escape(EMG_CONFIG.ena.portal_search_api)}\\?result=analysis&query=.*{re.escape(scenario.study_accession)}.*"
         ),
+        is_reusable=True,
         json=[
             {
                 "sample_accession": scenario.sample_accession,
@@ -1112,6 +1123,7 @@ def test_prefect_analyse_assembly_flow_invalid_schema(
         url=re.compile(
             f"{re.escape(EMG_CONFIG.ena.portal_search_api)}\\?result=read_run&query=.*{re.escape(scenario.study_accession)}.*"
         ),
+        is_reusable=True,
         json=[
             {
                 "sample_accession": scenario.sample_accession,

--- a/workflows/tests/test_analysis_rawreads_study_flow.py
+++ b/workflows/tests/test_analysis_rawreads_study_flow.py
@@ -21,7 +21,10 @@ import analyses.models
 from workflows.data_io_utils.file_rules.base_rules import FileRule, GlobRule
 from workflows.data_io_utils.file_rules.common_rules import GlobHasFilesCountRule
 from workflows.data_io_utils.file_rules.nodes import Directory
-from workflows.ena_utils.ena_api_requests import ENALibraryStrategyPolicy
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
+)
 from workflows.flows.analyse_study_tasks.cleanup_pipeline_directories import (
     # delete_study_results_dir,
     delete_study_nextflow_workdir,
@@ -543,6 +546,7 @@ def test_prefect_analyse_rawreads_flow(
         biome: BiomeChoices
         watchers: List[UserChoices]
         library_strategy_policy: Optional[ENALibraryStrategyPolicy]
+        library_source_policy: Optional[ENALibrarySourcePolicy]
         functional_analysis: bool
         webin_owner: Optional[str]
 
@@ -552,6 +556,7 @@ def test_prefect_analyse_rawreads_flow(
                 biome=BiomeChoices["root.engineered"],
                 watchers=[UserChoices[admin_user.username]],
                 library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                library_source_policy=ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
                 functional_analysis=True,
                 webin_owner=None,
             )
@@ -1089,6 +1094,7 @@ def test_prefect_analyse_rawreads_flow_private_data(
         biome: BiomeChoices
         watchers: List[UserChoices]
         library_strategy_policy: Optional[ENALibraryStrategyPolicy]
+        library_source_policy: Optional[ENALibrarySourcePolicy]
         functional_analysis: bool
         webin_owner: Optional[str]
 
@@ -1098,6 +1104,7 @@ def test_prefect_analyse_rawreads_flow_private_data(
                 biome=BiomeChoices["root.engineered"],
                 watchers=[UserChoices[admin_user.username]],
                 library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                library_source_policy=ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
                 functional_analysis=True,
                 webin_owner="webin-1",
             )
@@ -1471,6 +1478,7 @@ def test_prefect_analyse_rawreads_flow_no_functional(
         biome: BiomeChoices
         watchers: List[UserChoices]
         library_strategy_policy: Optional[ENALibraryStrategyPolicy]
+        library_source_policy: Optional[ENALibrarySourcePolicy]
         functional_analysis: bool
         webin_owner: Optional[str]
 
@@ -1480,6 +1488,7 @@ def test_prefect_analyse_rawreads_flow_no_functional(
                 biome=BiomeChoices["root.engineered"],
                 watchers=[UserChoices[admin_user.username]],
                 library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                library_source_policy=ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
                 functional_analysis=False,
                 webin_owner=None,
             )

--- a/workflows/tests/test_assemble_study_flow.py
+++ b/workflows/tests/test_assemble_study_flow.py
@@ -149,7 +149,7 @@ def test_prefect_assemble_study_flow(
         url=f"{EMG_CONFIG.ena.portal_search_api}?"
         f"result=read_run"
         f"&query=%22%28study_accession={study_accession}%20OR%20secondary_study_accession={study_accession}%29%22"
-        f"&limit=5000"
+        f"&limit=10000"
         f"&format=json"
         f"&fields=run_accession%2Csample_accession%2Csample_title%2Csecondary_sample_accession%2Cfastq_md5%2Cfastq_ftp%2Clibrary_layout%2Clibrary_strategy%2Clibrary_source%2Cscientific_name%2Chost_tax_id%2Chost_scientific_name%2Cinstrument_platform%2Cinstrument_model%2Clocation%2Clat%2Clon"
         f"&dataPortal=metagenome",
@@ -676,7 +676,7 @@ def test_prefect_assemble_private_study_flow(
         url=f"{EMG_CONFIG.ena.portal_search_api}?"
         f"result=read_run"
         f"&query=%22%28study_accession={study_accession}%20OR%20secondary_study_accession={study_accession}%29%22"
-        f"&limit=5000"
+        f"&limit=10000"
         f"&format=json"
         f"&fields=run_accession%2Csample_accession%2Csample_title%2Csecondary_sample_accession%2Cfastq_md5%2Cfastq_ftp%2Clibrary_layout%2Clibrary_strategy%2Clibrary_source%2Cscientific_name%2Chost_tax_id%2Chost_scientific_name%2Cinstrument_platform%2Cinstrument_model%2Clocation%2Clat%2Clon"
         f"&dataPortal=metagenome",

--- a/workflows/tests/test_assemble_study_flow.py
+++ b/workflows/tests/test_assemble_study_flow.py
@@ -17,7 +17,10 @@ import analyses.models
 import ena.models
 from workflows.data_io_utils.file_rules.base_rules import GlobRule
 from workflows.data_io_utils.file_rules.nodes import Directory
-from workflows.ena_utils.ena_api_requests import ENALibraryStrategyPolicy
+from workflows.ena_utils.ena_policies import (
+    ENALibrarySourcePolicy,
+    ENALibraryStrategyPolicy,
+)
 from workflows.flows.analyse_study_tasks.cleanup_pipeline_directories import (
     # delete_study_results_dir,
     delete_assemble_study_nextflow_workdir,
@@ -51,6 +54,7 @@ def assembly_study_input_mocker(biome_choices, user_choices):
         watchers: List[user_choices]
         wait_for_samplesheet_editing: bool
         library_strategy_policy: ENALibraryStrategyPolicy
+        library_source_policy: ENALibrarySourcePolicy
 
     return MockAssembleStudyInput
 
@@ -333,6 +337,7 @@ def test_prefect_assemble_study_flow(
                 watchers=[user_choices[admin_user.username]],
                 wait_for_samplesheet_editing=False,
                 library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                library_source_policy=ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
             )
 
     mock_suspend_flow_run.side_effect = suspend_side_effect
@@ -496,6 +501,7 @@ def test_prefect_assemble_study_flow(
 
     source = mgys.results_dir_path
     target = Path(mgys.external_results_dir)
+    shutil.rmtree(target, ignore_errors=True)
 
     # test deleting where not everything is copied
     allowed_extensions = {
@@ -729,6 +735,7 @@ def test_prefect_assemble_private_study_flow(
                 watchers=[user_choices[admin_user.username]],
                 wait_for_samplesheet_editing=False,
                 library_strategy_policy=ENALibraryStrategyPolicy.ONLY_IF_CORRECT_IN_ENA,
+                library_source_policy=ENALibrarySourcePolicy.OVERRIDE_GENOMIC_IF_METAGENOMIC_SCIENTIFIC_NAME,
             )
 
     mock_suspend_flow_run.side_effect = suspend_side_effect

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -17,7 +17,6 @@ from workflows.ena_utils.ena_accession_matching import (
     extract_study_accession_from_study_title,
 )
 from workflows.ena_utils.ena_api_requests import (
-    PRIMARY_METAGENOME_ASSEMBLY_TYPE,
     ENALibraryStrategyPolicy,
     get_study_from_ena,
     get_study_readruns_from_ena,
@@ -26,6 +25,7 @@ from workflows.ena_utils.ena_api_requests import (
     library_strategy_policy_to_filter,
     sync_privacy_state_of_ena_study_and_derived_objects,
 )
+from workflows.ena_utils.ena_policies import PRIMARY_METAGENOME_ASSEMBLY_TYPE
 from workflows.ena_utils.requestors import (
     ENAAccessException,
     ENAAPIRequest,


### PR DESCRIPTION
This PR:
* adds more options for overriding library source & strategy of ENA run metadata
  * the existing `ENALibraryStrategyPolicy` now also propagates to the `Run.experiment_type` field in the DB, rather than only controlling what gets put on pipeline samplesheets. I.e., it is persisted.
* a new `ENALibrarySourcePolicy` is added, similar to the strategy policy. 
  * It has a default value which means if a run's scientific-name metadata is like "*metagenome", we ignore the fact that the library source is `GENOMIC` or `OTHER` – two very common incorrect metadata cases.
  * like the library strategy policy, the library source policy can be chosen when starting/retrying a prefect analysis flow run. It too is persisted so it helps get "correct" (i.e., curated) `Run.experiment_type` values as well as just making the right runs appear on sample sheets.

Together these should by default handle cases like an amplicon run of these reads:

```tsv
run_accession	library_layout	library_strategy	library_source	tax_id	scientific_name
SRR22284878	PAIRED	AMPLICON	GENOMIC	408172	marine metagenome
SRR22284880	PAIRED	AMPLICON	GENOMIC	408172	marine metagenome
```

There is also a management command to try and migrate older Runs and Analyses to this updated logic, e.g. there are 20K Runs with UNKNOWN in the MGnify DB, and 4K of those just have the wrong `library_source` which would be corrected here.

---

2 unrelated bug fixes.

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
