### PR TITLE
Add assembly type filter to ENA analysis query

### DIFF
--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -511,6 +511,12 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
 
     ena_auth = dcc_auth if study.is_private else None
 
+    # Restrict to primary metagenome assemblies only
+    assembly_query = (
+        ENAAnalysisQuery(study_accession=accession)
+        | ENAAnalysisQuery(secondary_study_accession=accession)
+    ) & ENAAnalysisQuery(assembly_type=PRIMARY_METAGENOME_ASSEMBLY_TYPE)
+
     # fetch all assemblies in the "assembly study"
     portal_assemblies = ENAAPIRequest(
         result=ENAPortalResultType.ANALYSIS,
@@ -529,10 +535,7 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
             _.GENERATED_FTP,
         ],
         limit=limit,
-        query=(
-        ENAAnalysisQuery(study_accession=accession)
-        | ENAAnalysisQuery(secondary_study_accession=accession)
-        ) & ENAAnalysisQuery(assembly_type=PRIMARY_METAGENOME_ASSEMBLY_TYPE),
+        query=assembly_query,
     ).get(auth=ena_auth)
 
     # read-runs may exist in the same study as the assemblies

--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -29,6 +29,7 @@ ALLOWED_LIBRARY_SOURCE: list = ["METAGENOMIC", "METATRANSCRIPTOMIC"]
 SINGLE_END_LIBRARY_LAYOUT: str = "SINGLE"
 PAIRED_END_LIBRARY_LAYOUT: str = "PAIRED"
 METAGENOME_SCIENTIFIC_NAME: str = "metagenome"
+PRIMARY_METAGENOME_ASSEMBLY_TYPE: str = '"primary metagenome"'
 
 EMG_CONFIG = settings.EMG_CONFIG
 
@@ -528,8 +529,10 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
             _.GENERATED_FTP,
         ],
         limit=limit,
-        query=ENAAnalysisQuery(study_accession=accession)
-        | ENAAnalysisQuery(secondary_study_accession=accession),
+        query=(
+        ENAAnalysisQuery(study_accession=accession)
+        | ENAAnalysisQuery(secondary_study_accession=accession)
+        ) & ENAAnalysisQuery(assembly_type=PRIMARY_METAGENOME_ASSEMBLY_TYPE),
     ).get(auth=ena_auth)
 
     # read-runs may exist in the same study as the assemblies

--- a/workflows/tests/test_ena_api_requests.py
+++ b/workflows/tests/test_ena_api_requests.py
@@ -11,11 +11,13 @@ from workflows.ena_utils.abstract import (
     ENAQueryOperators,
     ENAQueryPair,
 )
+from workflows.ena_utils.analysis import ENAAnalysisQuery
 from workflows.ena_utils.ena_accession_matching import (
     extract_all_accessions,
     extract_study_accession_from_study_title,
 )
 from workflows.ena_utils.ena_api_requests import (
+    PRIMARY_METAGENOME_ASSEMBLY_TYPE,
     ENALibraryStrategyPolicy,
     get_study_from_ena,
     get_study_readruns_from_ena,
@@ -829,6 +831,15 @@ def test_ena_api_query_maker(httpx_mock):
         "result": "study",
         "dataPortal": "metagenome",
     }
+
+    assemblies_query = (
+        ENAAnalysisQuery(study_accession="ERP1")
+        | ENAAnalysisQuery(secondary_study_accession="ERP1")
+    ) & ENAAnalysisQuery(assembly_type=PRIMARY_METAGENOME_ASSEMBLY_TYPE)
+    assert (
+        str(assemblies_query)
+        == '((study_accession=ERP1 OR secondary_study_accession=ERP1) AND assembly_type="primary metagenome")'
+    )
 
     # calling API
     httpx_mock.add_response(


### PR DESCRIPTION
This PR:
When automation fetches assemblies for a study it collects all `analyses` regardless of type. Those currently also include "binned metagenomes" (bins) that we don't want to analyse with ASA.
In this PR I modified query to only fetch "primary metagenomes"


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [ ] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [ ] The command `task make-dev-data` still works
- [ ] The local docker-compose dev environment still works (`task run`)
- [ ] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [ ] The code style guide in `README.md` has been followed
