### PR TITLE
Tidy up a change to handle assemblies that not linked to any runs

### DIFF
--- a/workflows/ena_utils/ena_api_requests.py
+++ b/workflows/ena_utils/ena_api_requests.py
@@ -595,8 +595,9 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
         else:
             run = mgnify_sample.runs.first()  # TODO: coassemblies? replicates?
 
+        assembly_accession = assembly_data[_.ANALYSIS_ACCESSION]
         assembly, __ = analyses.models.Assembly.objects.update_or_create_by_accession(
-            known_accessions=[assembly_data[_.ANALYSIS_ACCESSION]],
+            known_accessions=[assembly_accession],
             defaults={
                 "sample": mgnify_sample,
                 "is_private": study.is_private,
@@ -610,14 +611,11 @@ def get_study_assemblies_from_ena(accession: str, limit: int = 10) -> list[str]:
         )
         assembly.metadata[_.GENERATED_FTP] = assembly_data[_.GENERATED_FTP]
 
-        # FIXME: Error - DETAIL:  Failing row contains (113467, 60323, null) for some studies such as PRJEB88595!
-        # I imagine some public assemblies are not linked to any runs
+        # It is possible that some assemblies are not linked to any runs, the ENA data model allows for this.
         if run:
             assembly.runs.add(run)
         else:
-            logger.error(
-                f"Could not find run for assembly {assembly_data[_.ANALYSIS_ACCESSION]}!"
-            )
+            logger.warning(f"Could not find run for assembly {assembly_accession}!")
         assembly.save()
         assemblies.append(assembly.first_accession)
     return assemblies


### PR DESCRIPTION
This should prevent cases when the assemblies are not linked to any runs. Which is correct as ENA allows this.

This came up with some of Sonya's @ochkalova studies. Specially PRJEB88595, @ochkalova can you check if the primary metagenomes in this study are not linked to any runs please?

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
