### PR TITLE
Fix incorrect legacy assembly <- assembly-analysis links

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -270,6 +270,9 @@ fileignoreconfig:
 - filename: workflows/flows/import_assemblies_from_filesystem_flow.py
   allowed_patterns: [key]
 
+- filename: workflows/flows/legacy/flows/relink_legacy_assembly_analyses.py
+  allowed_patterns: [key]
+
 - filename: workflows/tests/test_backfill_assembly_analysis_results_dirs_flow.py
   allowed_patterns: [key]
 

--- a/workflows/flows/legacy/flows/relink_legacy_assembly_analyses.py
+++ b/workflows/flows/legacy/flows/relink_legacy_assembly_analyses.py
@@ -1,0 +1,144 @@
+from django.db.models import QuerySet
+from prefect import get_run_logger
+from prefect.artifacts import create_table_artifact
+from sqlalchemy import select
+
+import activate_django_first  # noqa
+
+from analyses.models import Analysis, Assembly
+from workflows.data_io_utils.legacy_emg_dbs import (
+    LegacyAnalysisJob,
+    legacy_emg_db_session,
+)
+from workflows.flows.legacy.tasks.make_assembly_from_legacy_emg_db import (
+    make_assembly_from_legacy_emg_db,
+)
+from workflows.prefect_utils.flows_utils import django_db_flow as flow
+
+
+def _assembly_analyses_queryset(
+    mgys: str | None = None,
+    mgys_gte: str | None = None,
+    mgys_lte: str | None = None,
+) -> QuerySet[Analysis]:
+    analyses = (
+        Analysis.objects.filter(assembly__isnull=False)
+        .select_related("study", "sample", "assembly", "study__ena_study")
+        .order_by("study__accession", "accession")
+    )
+
+    if mgys:
+        analyses = analyses.filter(study__accession=mgys)
+    if mgys_gte:
+        analyses = analyses.filter(study__accession__gte=mgys_gte)
+    if mgys_lte:
+        analyses = analyses.filter(study__accession__lte=mgys_lte)
+
+    return analyses
+
+
+def _get_unique_assembly_by_ena_accession(accession: str) -> Assembly | None:
+    assemblies = Assembly.objects.filter(ena_accessions__contains=[accession])
+    if assemblies.count() > 1:
+        raise Assembly.MultipleObjectsReturned(
+            f"Multiple assemblies found with accession {accession}"
+        )
+    return assemblies.first()
+
+
+@flow(
+    name="Relink legacy assembly analyses",
+    flow_run_name="Relink legacy assembly analyses",
+)
+def relink_legacy_assembly_analyses(
+    mgys: str | None = None,
+    mgys_gte: str | None = None,
+    mgys_lte: str | None = None,
+    dry_run: bool = True,
+) -> list[dict]:
+    """
+    Repoint imported legacy assembly analyses to the Assembly matching their legacy ERZ.
+
+    The legacy importer stores MGYA numeric IDs from legacy ANALYSIS_JOB.JOB_ID, so this
+    flow uses each analysis id to fetch the legacy job and its ASSEMBLY.ACCESSION.
+    """
+    logger = get_run_logger()
+    analyses = list(_assembly_analyses_queryset(mgys, mgys_gte, mgys_lte))
+    changes = []
+
+    logger.info(f"Checking {len(analyses)} assembly analyses")
+
+    with legacy_emg_db_session() as session:
+        for analysis in analyses:
+            legacy_analysis = session.scalar(
+                select(LegacyAnalysisJob).where(LegacyAnalysisJob.job_id == analysis.id)
+            )
+            if not legacy_analysis:
+                logger.warning(f"No legacy analysis found for {analysis.accession}")
+                continue
+            if not legacy_analysis.assembly:
+                logger.warning(
+                    f"Legacy analysis {analysis.accession} has no linked assembly"
+                )
+                continue
+
+            legacy_assembly = legacy_analysis.assembly
+            legacy_accession = legacy_assembly.accession
+            current_assembly = analysis.assembly
+            current_accessions = current_assembly.ena_accessions or []
+
+            if legacy_accession in current_accessions:
+                logger.info(
+                    f"{analysis.accession} already points to assembly with {legacy_accession}"
+                )
+                continue
+
+            target_assembly = _get_unique_assembly_by_ena_accession(legacy_accession)
+            change = {
+                "analysis": analysis.accession,
+                "study": analysis.study.accession,
+                "legacy_assembly_accession": legacy_accession,
+                "current_assembly_id": current_assembly.id,
+                "current_assembly_accessions": ", ".join(current_accessions),
+                "target_assembly_id": target_assembly.id if target_assembly else None,
+                "action": "would_update" if dry_run else "updated",
+            }
+
+            if dry_run:
+                change["action"] = (
+                    "would_update_to_existing_assembly"
+                    if target_assembly
+                    else "would_create_assembly_and_update"
+                )
+                logger.info(change)
+                changes.append(change)
+                continue
+
+            target_assembly = make_assembly_from_legacy_emg_db(
+                legacy_assembly,
+                analysis.study,
+                analysis.sample,
+            )
+            analysis.assembly = target_assembly
+            analysis.save(update_fields=["assembly"])
+            change["target_assembly_id"] = target_assembly.id
+            logger.info(change)
+            changes.append(change)
+
+    if changes:
+        create_table_artifact(
+            key="legacy-assembly-analysis-relinking",
+            table=changes,
+            description=(
+                "Legacy assembly analysis links that would change"
+                if dry_run
+                else "Legacy assembly analysis links changed"
+            ),
+        )
+
+    logger.info(
+        f"{len(changes)} analyses need relinking"
+        if dry_run
+        else f"Relinked {len(changes)} analyses"
+    )
+    return changes

--- a/workflows/flows/legacy/tasks/make_assembly_from_legacy_emg_db.py
+++ b/workflows/flows/legacy/tasks/make_assembly_from_legacy_emg_db.py
@@ -18,6 +18,34 @@ from workflows.flows.legacy.tasks.make_sample_from_legacy_emg_db import (
 )
 
 
+def get_or_create_assembly_for_legacy_accession(
+    legacy_assembly: LegacyAssembly,
+    study: Study,
+    sample: Sample,
+) -> tuple[Assembly, bool]:
+    matching_assemblies = Assembly.objects.filter(
+        ena_accessions__contains=[legacy_assembly.accession]
+    )
+    if matching_assemblies.count() > 1:
+        raise Assembly.MultipleObjectsReturned(
+            f"Multiple assemblies found with accession {legacy_assembly.accession}"
+        )
+
+    assembly = matching_assemblies.first()
+    if assembly:
+        return assembly, False
+
+    return (
+        Assembly.objects.create(
+            ena_study=study.ena_study,
+            assembly_study=study,  # could also be reads study, but unclear from information present for legacy cases
+            sample=sample,
+            ena_accessions=[legacy_assembly.accession],
+        ),
+        True,
+    )
+
+
 @task
 def make_assembly_from_legacy_emg_db(
     legacy_assembly: LegacyAssembly,
@@ -32,13 +60,10 @@ def make_assembly_from_legacy_emg_db(
         # In this new schema, Assembly has a sample field and runs ManyToMany.
         # A co-assembly might have multiple runs and samples.
         # For now we use the analysis job's primary sample for the assembly.
-        assembly, created = Assembly.objects.get_or_create(
-            ena_study=study.ena_study,
-            assembly_study=study,  # could also be reads study, but unclear from information present for legacy cases
-            sample=sample,
-            defaults={
-                "ena_accessions": [legacy_assembly.accession],
-            },
+        assembly, created = get_or_create_assembly_for_legacy_accession(
+            legacy_assembly,
+            study,
+            sample,
         )
         if created:
             logger.info(f"Created new Assembly object {assembly}")

--- a/workflows/tests/test_import_legacy_analyses.py
+++ b/workflows/tests/test_import_legacy_analyses.py
@@ -5,8 +5,9 @@ import pytest
 from sqlalchemy import select
 
 import ena.models
-from analyses.models import Analysis, Sample, Study
+from analyses.models import Analysis, Assembly, Sample, Study
 from workflows.data_io_utils.legacy_emg_dbs import (
+    LegacyAssembly,
     LegacySample,
     LegacyStudy,
     legacy_emg_db_session,
@@ -14,6 +15,9 @@ from workflows.data_io_utils.legacy_emg_dbs import (
 from workflows.flows.legacy.flows.import_legacy_analyses import (
     import_all_legacy_analyses,
     import_legacy_analyses,
+)
+from workflows.flows.legacy.tasks.make_assembly_from_legacy_emg_db import (
+    get_or_create_assembly_for_legacy_accession,
 )
 from workflows.flows.legacy.tasks.make_sample_from_legacy_emg_db import (
     make_sample_from_legacy_emg_db,
@@ -300,6 +304,53 @@ def test_make_sample_from_legacy_emg_db_multiple_studies(prefect_harness):
 
     # Also check ena_sample has NOT changed its study (ENA samples are 1:1 with ENA studies in our simplified data model)
     assert returned_sample.ena_sample.study == ena_study_1
+
+
+@pytest.mark.django_db
+def test_legacy_assembly_import_matches_by_erz_accession(prefect_harness):
+    ena_study = ena.models.Study.objects.create(accession="ERP1", title="Study 1")
+    mg_study = Study.objects.create(
+        ena_study=ena_study,
+        title="Study 1",
+        ena_accessions=["ERP1"],
+    )
+
+    ena_sample = ena.models.Sample.objects.create(
+        accession="SAMEA1",
+        additional_accessions=["ERS1"],
+        study=ena_study,
+    )
+    sample = Sample.objects.create(
+        ena_sample=ena_sample,
+        ena_study=ena_study,
+        ena_accessions=["SAMEA1", "ERS1"],
+    )
+    sample.studies.add(mg_study)
+
+    wrong_existing_assembly = Assembly.objects.create(
+        ena_study=ena_study,
+        assembly_study=mg_study,
+        sample=sample,
+        ena_accessions=["ERZ_WRONG_ASSEMBLER"],
+    )
+
+    legacy_assembly = LegacyAssembly(
+        assembly_id=1,
+        accession="ERZ_RIGHT_ASSEMBLER",
+        study_id=5000,
+        experiment_type_id=4,
+    )
+
+    assembly, created = get_or_create_assembly_for_legacy_accession(
+        legacy_assembly,
+        mg_study,
+        sample,
+    )
+
+    assert created is True
+    assert assembly.id != wrong_existing_assembly.id
+    assert assembly.ena_accessions == ["ERZ_RIGHT_ASSEMBLER"]
+    assert Assembly.objects.count() == 2
 
 
 @pytest.mark.httpx_mock(should_mock=should_not_mock_httpx_requests_to_prefect_server)


### PR DESCRIPTION
This PR:
* fixes a bug where, when importing legacy data, assembly-analyses (e.g. v5) may be linked to the incorrect assembly
  * this occurs in very limited cases where a study contains multiple assemblies based on the same sample, typically e.g. a megahit assembly and a later metaspades assembly
  * the bug was an overly broad get-or-create
* adds a one-off prefect flow to relink (aka migrate) any assembly-analyses to their correct assembly, by going through all assembly-analyses and rechecking the legacy db
  * this is for envs where the legacy import has already happened

There is a dry-run mode to run in prod first to check what will happen.

---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
