### PR TITLE
adds slurm-web dashboard to donco dev slurm cluster

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -42,7 +42,7 @@ fileignoreconfig:
   allowed_patterns: [kubectl create secret generic nginx-private-data-config-secret --from-file=private-data-nginx.conf -n emgapiv2-hl-exp, google-maps-key-secret, create secret generic, google-maps-key]
 
 - filename: docker-compose.yaml
-  allowed_patterns: [EMG_WEBIN__JWT_SECRET_KEY=dummy-key, SECURE_LINK_SECRET=dummy-key]
+  checksum: a2a08ad2c13767992ee803ce4af5492907c1343b007c4a4ef3e22af052a751d4
 
 - filename: emgapiv2/api/__init__.py
   allowed_patterns: [OpenApiKeywords]
@@ -109,6 +109,9 @@ fileignoreconfig:
 
 - filename: slurm-dev-environment/configs/private-data-nginx.conf
   checksum: e3bb31e2a0f97c62ee684dd7124e5b72db364c52088ddd98331310909c6a0493
+
+- filename: slurm-dev-environment/configs/slurm-web.key
+  checksum: fa15c0de5c2acfe9a1872526026eb9a9110c782257c2fde6575361d3d2701fcb
 
 - filename: slurm-dev-environment/fs/nfs/public/tests/amplicon_v6_output/SRR1111111/taxonomy-summary/DADA2-SILVA/SRR1111111_16S-V3-V4.html
   checksum: cbba3d78df18143c2d69885815740506ea76787d481f94748c79627737222ce4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -228,6 +228,38 @@ services:
     profiles: ["slurm", "all"]
     networks: [slurm, "emg"]
 
+  slurm-web-agent:
+    image: ghcr.io/rackslab/slurm-web-agent:v7.0.0
+    platform: linux/amd64  # Slurm-web does not currently publish an arm64 image
+    container_name: slurm-web-agent
+    restart: unless-stopped
+    depends_on:
+      slurm_node:
+        condition: service_started
+    volumes:
+      - "./slurm-dev-environment/configs/slurm-web-agent.ini:/etc/slurm-web/agent.ini:ro"
+      - "./slurm-dev-environment/configs/slurm-web.key:/var/lib/slurm-web/jwt.key:ro"
+      - "./slurm-dev-environment/configs/jwt_hs256.key:/var/lib/slurm-web/slurmrestd.key:ro"
+    profiles: ["slurm", "all"]
+    networks: [slurm]
+
+  slurm-web-gateway:
+    image: ghcr.io/rackslab/slurm-web-gateway:v7.0.0
+    platform: linux/amd64  # Slurm-web does not currently publish an arm64 image
+    container_name: slurm-web-gateway
+    restart: unless-stopped
+    depends_on:
+      slurm-web-agent:
+        condition: service_started
+    volumes:
+      - "./slurm-dev-environment/configs/slurm-web-gateway.ini:/etc/slurm-web/gateway.ini:ro"
+      - "./slurm-dev-environment/configs/slurm-web.key:/var/lib/slurm-web/jwt.key:ro"
+      - "./slurm-dev-environment/configs/slurm-web.key:/var/lib/slurm-web/session.key:ro"
+    ports:
+      - "5011:5011"
+    profiles: ["slurm", "all"]
+    networks: [slurm]
+
 volumes:
   prefectdb:
   appdb:

--- a/slurm-dev-environment/README.md
+++ b/slurm-dev-environment/README.md
@@ -17,6 +17,7 @@ It starts:
   * [Slurm controller / central manager daemon](https://slurm.schedmd.com/slurmctld.html). This is the node workers poll for jobs.
   * [Slurm compute node daemon](https://slurm.schedmd.com/slurmd.html). Acts as a node that executes jobs in the queue.
   * [Slurm rest api daemon](https://slurm.schedmd.com/slurmrestd.html). Listens for requests on port `6820`.
+  * `slurm-web-agent` and `slurm-web-gateway`: a [Slurm-web](https://docs.rackslab.io/slurm-web/) dashboard available at http://localhost:5011.
 
 The `entrypoint.sh` scripts start the respective daemons.
 
@@ -34,6 +35,14 @@ This is to help with writing jobs for EBI Codon Slurm infrastructure, which look
 
 ### Data and filesystems
 There are dummy HPS and NFS filesystems at `/hps` and `/nfs/production`. On a `datamover` partitioned job, there is also `/nfs/public`.
+
+Flows that publish files (e.g. from a "production" or hps filesystem to ftp)
+call the nested `move-data/move_data_deployment`, which  runs on the `datamover` partition.
+Register it, along with the other Donco deployments, before running those flows:
+
+```shell
+task deploy-all
+```
 
 ## Using it
 ### Interactively on the nodes

--- a/slurm-dev-environment/configs/slurm-web-agent.ini
+++ b/slurm-dev-environment/configs/slurm-web-agent.ini
@@ -1,0 +1,8 @@
+[service]
+cluster=donco
+
+[slurmrestd]
+uri=http://slurm_node:6820
+
+[racksdb]
+enabled=no

--- a/slurm-dev-environment/configs/slurm-web-gateway.ini
+++ b/slurm-dev-environment/configs/slurm-web-gateway.ini
@@ -1,0 +1,2 @@
+[agents]
+url=http://slurm-web-agent:5012

--- a/slurm-dev-environment/configs/slurm-web.key
+++ b/slurm-dev-environment/configs/slurm-web.key
@@ -1,0 +1,1 @@
+donco-slurm-web-local-development-only-secret-key-do-not-use-in-production

--- a/slurm-dev-environment/configs/slurm.conf
+++ b/slurm-dev-environment/configs/slurm.conf
@@ -42,7 +42,7 @@ SlurmdDebug=debug
 SlurmdLogFile=/var/log/slurm/slurmd.log
 
 # COMPUTE NODES
-NodeName=slurm_node CPUs=4 RealMemory=2000 State=UNKNOWN
+NodeName=slurm_node CPUs=4 RealMemory=4096 State=UNKNOWN
 NodeName=prefect-agent  # login/submit node
 PartitionName=debug Nodes=slurm_node Default=YES MaxTime=INFINITE State=UP
 PartitionName=datamover Nodes=slurm_node Default=NO MaxTime=INFINITE State=UP


### PR DESCRIPTION
This PR:
* adds the [slurm-web](https://docs.rackslab.io/slurm-web/usage/manpages/slurm-web-gateway.html) containers and configs to the local `donco` slurm cluster (in docker-compose) to help debug/view slurm jobs on the local cluster. This is just a debugging/local-dev aid.


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
