### PR TITLE
Upgrade prefect-slurm to 0.1.6 (fixes concurrency limits)

### DIFF
--- a/deployment/ebi-wp-k8s-hl/ebi-wp-k8s-hl.yaml
+++ b/deployment/ebi-wp-k8s-hl/ebi-wp-k8s-hl.yaml
@@ -283,7 +283,7 @@ items:
                       key: PREFECT_SERVER_API_AUTH_STRING
                       name: emgapi-secret
                 - name: EXTRA_PIP_PACKAGES
-                  value: httpx[cli] nextflowpy prefect-slurm==0.1.5
+                  value: httpx[cli] nextflowpy prefect-slurm==0.1.6
                 - name: PREFECT_LOCAL_STORAGE_PATH
                   value: /app/data/prefect/storage
                 - name: PREFECT_LOGGING_LEVEL

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - PREFECT_API_URL=http://127.0.0.1:4200/api
       - PREFECT_SERVER_API_HOST=0.0.0.0
       - PREFECT_API_DATABASE_CONNECTION_URL=postgresql+asyncpg://postgres:postgres@prefect-database:5432/prefect
-      - EXTRA_PIP_PACKAGES=httpx[cli] prefect-slurm==0.1.5
+      - EXTRA_PIP_PACKAGES=httpx[cli] prefect-slurm==0.1.6
       - PREFECT_LOCAL_STORAGE_PATH=/root/.prefect/storage
     healthcheck:
       interval: 2s

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ prefect==3.4.19
 fastapi==0.123.6
 prefect-shell==0.3.1
 prefect-slack==0.3.1
-prefect-slurm==0.1.5
+prefect-slurm==0.1.6
 importlib-metadata==8.7.1
 
 # Pydantic


### PR DESCRIPTION
This PR:
* bumps the version of prefect-slurm used to 0.1.6, which helps to respect prefect concurrency limits


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
