### PR TITLE
Suppression state bugfix/refactor

### DIFF
--- a/analyses/base_models/base_models.py
+++ b/analyses/base_models/base_models.py
@@ -11,6 +11,7 @@ from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import models
 
 import ena.models
+from emgapiv2.model_manager_mixins import SuppressionFilterManagerMixin
 
 
 class SelectRelatedEnaStudyManagerMixin:
@@ -235,12 +236,6 @@ class TimeStampedModel(models.Model):
 
     class Meta:
         abstract = True
-
-
-class SuppressionFilterManagerMixin:
-    def get_queryset(self):
-        qs = super().get_queryset()
-        return qs.filter(is_suppressed=False)
 
 
 class PrivacyFilterManagerMixin(SuppressionFilterManagerMixin):

--- a/analyses/base_models/with_status_models.py
+++ b/analyses/base_models/with_status_models.py
@@ -7,16 +7,7 @@ from django.db.models import Q, QuerySet
 
 
 class SelectByStatusQueryset(QuerySet):
-    def __init__(
-        self,
-        model=None,
-        query=None,
-        using=None,
-        hints=None,
-        status_fieldname: str = "status",
-    ):
-        self.status_fieldname = status_fieldname
-        super().__init__(model, query, using, hints)
+    STATUS_FIELDNAME = "status"
 
     def _build_q_objects(
         self, keys: List[Union[str, Enum]], allow_null: bool, truthy_target: bool
@@ -26,12 +17,12 @@ class SelectByStatusQueryset(QuerySet):
             status_label = status.value if isinstance(status, Enum) else status
             if allow_null:
                 filters.append(
-                    Q(**{f"{self.status_fieldname}__{status_label}": truthy_target})
+                    Q(**{f"{self.STATUS_FIELDNAME}__{status_label}": truthy_target})
                 )
             else:
                 filters.append(
-                    Q(**{f"{self.status_fieldname}__{status_label}": truthy_target})
-                    | Q(**{f"{self.status_fieldname}__{status_label}__isnull": True})
+                    Q(**{f"{self.STATUS_FIELDNAME}__{status_label}": truthy_target})
+                    | Q(**{f"{self.STATUS_FIELDNAME}__{status_label}__isnull": True})
                 )
         return filters
 
@@ -40,7 +31,7 @@ class SelectByStatusQueryset(QuerySet):
     ):
         """
         Filter queryset by a combination of statuses in the object's status json field.
-        :param statuses_to_be_true: List of keys that should resolve to true values in the model's status_fieldname json field.
+        :param statuses_to_be_true: List of keys that should resolve to true values in the model's status JSON field.
         :param strict: If True, objects will be filtered out if the key is not present. If False, null values are also acceptable i.e. only falsey values will be excluded.
         """
         if not statuses_to_be_true:
@@ -54,7 +45,7 @@ class SelectByStatusQueryset(QuerySet):
     ):
         """
         Filter queryset by excluding a combination of statuses in the object's status json field.
-        :param statuses_to_exclude: List of keys that, if they resolve to false values in the model's status_fieldname json field, will exclude that object from the queryset.
+        :param statuses_to_exclude: List of keys that, if they resolve to false values in the model's status JSON field, will exclude that object from the queryset.
         :param strict: If True, objects will only be excluded if the key is present AND truthy. If False, null values are also excluded.
         """
         if not statuses_to_exclude:
@@ -71,7 +62,6 @@ class SelectByStatusManagerMixin:
 
     Use:
     class MyModelManager(SelectByStatusManagerMixin, models.Manager):...
-        STATUS_FIELDNAME = "my_status_field"
 
     class MyModel(...):
         objects = MyModelManager()
@@ -79,12 +69,10 @@ class SelectByStatusManagerMixin:
     MyModel.objects.filter_by_statuses(["is_it_started"]).exclude_by_statuses(["is_it_finished"]).
     """
 
-    STATUS_FIELDNAME = "status"
-
-    def get_queryset(self):
-        return SelectByStatusQueryset(
-            status_fieldname=self.STATUS_FIELDNAME, using=self._db, model=self.model
-        )
+    # Manager.get_queryset() instantiates self._queryset_class. Declaring the
+    # class here lets the normal cooperative get_queryset() chain build the
+    # custom queryset without bypassing any other manager mixins.
+    _queryset_class = SelectByStatusQueryset
 
     def exclude_by_statuses(self, *args, **kwargs):
         return self.get_queryset().exclude_by_statuses(*args, **kwargs)

--- a/analyses/models.py
+++ b/analyses/models.py
@@ -37,6 +37,7 @@ from analyses.base_models.with_experiment_type_models import WithExperimentTypeM
 from analyses.base_models.with_status_models import SelectByStatusManagerMixin
 from analyses.base_models.with_watchers_models import WithWatchersModel
 from emgapiv2.enum_utils import DjangoChoicesCompatibleStrEnum, FutureStrEnum
+from emgapiv2.model_manager_mixins import SuppressionFilterManagerMixin
 from emgapiv2.model_utils import JSONFieldWithSchema
 from workflows.ena_utils.ena_accession_matching import (
     ENA_ASSEMBLY_ACCESSION_REGEX,
@@ -116,6 +117,9 @@ class StudyManager(ENADerivedManager):
         return study
 
 
+class NotSuppressedStudyManager(SuppressionFilterManagerMixin, StudyManager): ...
+
+
 class PublicStudyManager(PrivacyFilterManagerMixin, StudyManager):
     """
     A custom manager that filters out private studies by default.
@@ -132,6 +136,7 @@ class Study(
     WithWatchersModel,
 ):
     objects: ClassVar[ENADerivedManager[Study]] = StudyManager()
+    objects_not_suppressed = NotSuppressedStudyManager()
     public_objects = PublicStudyManager()
 
     PREFERRED_ENA_ACCESSION_REGEX = INSDC_STUDY_ACCESSION_REGEX
@@ -214,6 +219,9 @@ class Study(
         ]
 
 
+class NotSuppressedSampleManager(SuppressionFilterManagerMixin, ENADerivedManager): ...
+
+
 class PublicSampleManager(PrivacyFilterManagerMixin, ENADerivedManager):
     """
     Manager for public samples, i.e. those not marked as private / pre-publication in ENA.
@@ -232,6 +240,7 @@ class Sample(InferredMetadataMixin, ENADerivedModel, TimeStampedModel):
     CommonMetadataKeys = ENASampleFields
 
     objects: ClassVar[ENADerivedManager[Sample]] = ENADerivedManager()
+    objects_not_suppressed = NotSuppressedSampleManager()
     public_objects = PublicSampleManager()
 
     id = models.AutoField(primary_key=True)
@@ -334,6 +343,9 @@ class SampleRelatedSample(models.Model):
         return f"{self.pk}: {self.declaring_sample} is {self.relation_type} {self.related_sample}"
 
 
+class NotSuppressedRunManager(SuppressionFilterManagerMixin, ENADerivedManager): ...
+
+
 class PublicRunManager(PrivacyFilterManagerMixin, models.Manager): ...
 
 
@@ -357,6 +369,7 @@ class Run(
         ION_TORRENT = "ION_TORRENT"
 
     objects: ClassVar[ENADerivedManager[Run]] = ENADerivedManager()
+    objects_not_suppressed = NotSuppressedRunManager()
     public_objects = PublicRunManager()
 
     id = models.AutoField(primary_key=True)
@@ -533,11 +546,15 @@ class AssemblyManager(SelectByStatusManagerMixin, ENADerivedManager):
             )
 
 
+class NotSuppressedAssemblyManager(SuppressionFilterManagerMixin, AssemblyManager): ...
+
+
 class PublicAssemblyManager(PrivacyFilterManagerMixin, AssemblyManager): ...
 
 
 class Assembly(InferredMetadataMixin, TimeStampedModel, ENADerivedModel):
     objects: ClassVar[ENADerivedManager[Assembly]] = AssemblyManager()
+    objects_not_suppressed = NotSuppressedAssemblyManager()
     public_objects = PublicAssemblyManager()
 
     PREFERRED_ENA_ACCESSION_REGEX = ENA_ASSEMBLY_ACCESSION_REGEX
@@ -830,6 +847,16 @@ class AnalysisManagerIncludingAnnotations(SelectByStatusManagerMixin, models.Man
         return super().get_queryset()
 
 
+class NotSuppressedAnalysisManager(
+    SuppressionFilterManagerMixin, AnalysisManagerDeferringAnnotations
+): ...
+
+
+class NotSuppressedAnalysisManagerIncludingAnnotations(
+    SuppressionFilterManagerMixin, AnalysisManagerIncludingAnnotations
+): ...
+
+
 class PublicAnalysisManager(
     PrivacyFilterManagerMixin, AnalysisManagerDeferringAnnotations
 ):
@@ -859,7 +886,8 @@ class Analysis(
     WithExperimentTypeModel,
 ):
     objects = AnalysisManagerDeferringAnnotations()
-    objects_and_annotations = AnalysisManagerIncludingAnnotations()
+    objects_not_suppressed = NotSuppressedAnalysisManager()
+    objects_and_annotations = NotSuppressedAnalysisManagerIncludingAnnotations()
 
     public_objects = PublicAnalysisManager()
     public_objects_and_annotations = PublicAnalysisManagerIncludingAnnotations()
@@ -1117,8 +1145,10 @@ def on_study_saved_update_analyses_suppression_states(
     This means there is no current way to suppress one analysis of a study, only entire studies.
     This is how ENA's documentation suggests suppression should work.
     """
-    analyses_to_update_suppression_of = instance.analyses.exclude(
-        is_suppressed=instance.is_suppressed
+    analyses_to_update_suppression_of = (
+        Analysis.objects.filter(study=instance)
+        .exclude(is_suppressed=instance.is_suppressed)
+        .only("pk", "accession", "is_suppressed")
     )
     for analysis in analyses_to_update_suppression_of:
         logger.info(

--- a/analyses/tests/test_models.py
+++ b/analyses/tests/test_models.py
@@ -434,6 +434,35 @@ def test_status_filtering(
         == 1
     )
 
+    # The suppression-aware managers compose with status filtering while the
+    # default manager remains unfiltered for internal and admin use.
+    analysis.status[analysis.AnalysisStates.ANALYSIS_COMPLETED] = True
+    analysis.is_suppressed = True
+    analysis.save()
+    assert (
+        Analysis.objects.filter_by_statuses(
+            [analysis.AnalysisStates.ANALYSIS_COMPLETED]
+        ).count()
+        == 1
+    )
+    assert (
+        Analysis.objects_not_suppressed.filter_by_statuses(
+            [analysis.AnalysisStates.ANALYSIS_COMPLETED]
+        ).count()
+        == 0
+    )
+    assert (
+        Analysis.objects_and_annotations.filter_by_statuses(
+            [analysis.AnalysisStates.ANALYSIS_COMPLETED]
+        ).count()
+        == 0
+    )
+    deferred_fields, is_deferred = (
+        Analysis.objects_not_suppressed.get_queryset().query.deferred_loading
+    )
+    assert is_deferred
+    assert "annotations" in deferred_fields
+
 
 @pytest.mark.django_db(transaction=True)
 def test_update_or_create_by_accession(raw_reads_mgnify_study):

--- a/emgapiv2/api/analyses.py
+++ b/emgapiv2/api/analyses.py
@@ -45,7 +45,7 @@ class AnalysisController(UnauthorisedIsUnfoundController):
     )
     def get_mgnify_analysis(self, accession: str):
         return self.get_object_or_exception(
-            analyses.models.Analysis.objects.select_related(
+            analyses.models.Analysis.objects_not_suppressed.select_related(
                 "run", "assembly", "study", "sample"
             ),
             accession=accession,
@@ -103,10 +103,10 @@ class AnalysisController(UnauthorisedIsUnfoundController):
     ):
         # TODO: this involves a duplicate DB query, can probably be a single query that is then perm checked
         self.get_object_or_exception(
-            analyses.models.Analysis.objects, accession=accession
+            analyses.models.Analysis.objects_not_suppressed, accession=accession
         )
         annotations = (
-            analyses.models.Analysis.objects.filter(accession=accession)
+            analyses.models.Analysis.objects_not_suppressed.filter(accession=accession)
             .values_list(f"annotations__{annotation_type.value}", flat=True)
             .first()
         )

--- a/emgapiv2/api/private.py
+++ b/emgapiv2/api/private.py
@@ -51,7 +51,7 @@ class MyDataController(ControllerBase):
     @paginate()
     def list_private_mgnify_studies(self):
         auth = self.context.request.auth
-        qs = analyses.models.Study.objects
+        qs = analyses.models.Study.objects_not_suppressed
 
         if auth and auth.is_superuser:
             qs = qs.all()

--- a/emgapiv2/api/runs.py
+++ b/emgapiv2/api/runs.py
@@ -130,7 +130,7 @@ class AnalysedRunController(UnauthorisedIsUnfoundController):
     )
     def get_analysed_run(self, accession: str):
         try:
-            run = analyses.models.Run.objects.get_by_accession(accession)
+            run = analyses.models.Run.objects_not_suppressed.get_by_accession(accession)
         except (
             analyses.models.Run.DoesNotExist,
             analyses.models.Run.MultipleObjectsReturned,
@@ -164,7 +164,7 @@ class AnalysedRunController(UnauthorisedIsUnfoundController):
     @paginate()
     def list_runs_analyses(self, accession: str):
         try:
-            run = analyses.models.Run.objects.get_by_accession(accession)
+            run = analyses.models.Run.objects_not_suppressed.get_by_accession(accession)
         except (
             analyses.models.Run.DoesNotExist,
             analyses.models.Run.MultipleObjectsReturned,
@@ -172,7 +172,9 @@ class AnalysedRunController(UnauthorisedIsUnfoundController):
             raise NotFound(detail=f"Analysed run with accession {accession} not found.")
         # raise not found if user doesn't have permission to see
         self.check_object_permissions(run)
-        return run.analyses.filter(is_ready=True)
+        return analyses.models.Analysis.objects_not_suppressed.filter(
+            run=run, is_ready=True
+        )
 
     @http_get(
         "/{accession}/assemblies/",
@@ -198,7 +200,7 @@ class AnalysedRunController(UnauthorisedIsUnfoundController):
     @paginate()
     def list_runs_assemblies(self, accession: str):
         try:
-            run = analyses.models.Run.objects.get_by_accession(accession)
+            run = analyses.models.Run.objects_not_suppressed.get_by_accession(accession)
         except (
             analyses.models.Run.DoesNotExist,
             analyses.models.Run.MultipleObjectsReturned,

--- a/emgapiv2/api/samples.py
+++ b/emgapiv2/api/samples.py
@@ -72,7 +72,9 @@ class SampleController(UnauthorisedIsUnfoundController):
     )
     def get_mgnify_sample(self, accession: str):
         try:
-            sample = analyses.models.Sample.objects.get_by_accession(accession)
+            sample = analyses.models.Sample.objects_not_suppressed.get_by_accession(
+                accession
+            )
         except (
             analyses.models.Sample.DoesNotExist,
             analyses.models.Sample.MultipleObjectsReturned,
@@ -127,9 +129,11 @@ class SampleController(UnauthorisedIsUnfoundController):
     )
     @paginate()
     def list_sample_runs(self, accession: str):
-        sample = analyses.models.Sample.objects.get_by_accession(accession)
+        sample = analyses.models.Sample.objects_not_suppressed.get_by_accession(
+            accession
+        )
         self.check_object_permissions(sample)
-        return sample.runs.all()
+        return analyses.models.Run.objects_not_suppressed.filter(sample=sample)
 
     @http_get(
         "/{accession}/assemblies/",
@@ -157,6 +161,8 @@ class SampleController(UnauthorisedIsUnfoundController):
     )
     @paginate()
     def list_sample_assemblies(self, accession: str):
-        sample = analyses.models.Sample.objects.get_by_accession(accession)
+        sample = analyses.models.Sample.objects_not_suppressed.get_by_accession(
+            accession
+        )
         self.check_object_permissions(sample)
-        return sample.assemblies.all()
+        return analyses.models.Assembly.objects_not_suppressed.filter(sample=sample)

--- a/emgapiv2/api/studies.py
+++ b/emgapiv2/api/studies.py
@@ -97,7 +97,7 @@ class StudyController(UnauthorisedIsUnfoundController):
     )
     def get_mgnify_study(self, accession: str):
         return self.get_object_or_exception(
-            analyses.models.Study.objects, accession=accession
+            analyses.models.Study.objects_not_suppressed, accession=accession
         )
 
     @http_get(
@@ -144,9 +144,12 @@ class StudyController(UnauthorisedIsUnfoundController):
     )
     @paginate()
     def list_mgnify_study_analyses(self, accession: str):
-        return self.get_object_or_exception(
-            analyses.models.Study.objects, accession=accession
-        ).analyses.filter(is_ready=True)
+        study = self.get_object_or_exception(
+            analyses.models.Study.objects_not_suppressed, accession=accession
+        )
+        return analyses.models.Analysis.objects_not_suppressed.filter(
+            study=study, is_ready=True
+        )
 
     @http_get(
         "/{accession}/publications/",
@@ -173,7 +176,7 @@ class StudyController(UnauthorisedIsUnfoundController):
     @paginate()
     def list_mgnify_study_publications(self, accession: str):
         return self.get_object_or_exception(
-            analyses.models.Study.objects, accession=accession
+            analyses.models.Study.objects_not_suppressed, accession=accession
         ).publications.all()
 
     @http_get(
@@ -200,6 +203,7 @@ class StudyController(UnauthorisedIsUnfoundController):
     )
     @paginate()
     def list_mgnify_study_samples(self, accession: str):
-        return self.get_object_or_exception(
-            analyses.models.Study.objects, accession=accession
-        ).samples.all()
+        study = self.get_object_or_exception(
+            analyses.models.Study.objects_not_suppressed, accession=accession
+        )
+        return analyses.models.Sample.objects_not_suppressed.filter(studies=study)

--- a/emgapiv2/model_manager_mixins.py
+++ b/emgapiv2/model_manager_mixins.py
@@ -1,0 +1,5 @@
+class SuppressionFilterManagerMixin:
+    """Filter suppressed rows from a cooperatively composed model manager."""
+
+    def get_queryset(self):
+        return super().get_queryset().filter(is_suppressed=False)

--- a/emgapiv2/test_data_privacy.py
+++ b/emgapiv2/test_data_privacy.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 from ninja_jwt.tokens import SlidingToken
 
-from analyses.models import Analysis, Run, Study
+from analyses.models import Analysis, Assembly, Run, Study
 from emgapiv2.api.auth import WebinJWTAuth
 from ena.models import Study as ENAStudy
 
@@ -55,6 +55,8 @@ def test_admin_view_studies(admin_client):
     """Test that admin interface shows all studies"""
     public_study = Study.objects.create(title="Public Study", is_private=False)
     private_study = Study.objects.create(title="Private Study", is_private=True)
+    public_study.is_suppressed = True
+    public_study.save()
 
     url = reverse("admin:analyses_study_changelist")
     response = admin_client.get(url)
@@ -70,6 +72,8 @@ def test_admin_view_analyses(raw_read_run, admin_client):
     """Test that admin interface shows all analyses"""
     public_analysis = create_analysis(is_private=False)
     private_analysis = create_analysis(is_private=True)
+    public_analysis.is_suppressed = True
+    public_analysis.save()
 
     url = reverse("admin:analyses_analysis_changelist")
     response = admin_client.get(url)
@@ -91,6 +95,7 @@ def test_study_manager_methods():
 
     assert Study.public_objects.count() == 1
     assert Study.public_objects.first() == public_study
+    assert Study.objects_not_suppressed.count() == 2
     assert Study.objects.count() == 2
     private_studies = Study.public_objects.private_only()
     # a bit odd naming, public_objects is really "privacy controlled objects but by default public"
@@ -107,6 +112,7 @@ def test_suppressed_study_manager_methods():
     private_study = Study.objects.create(title="Private Study", is_private=True)
 
     assert Study.public_objects.count() == 1
+    assert Study.objects_not_suppressed.count() == 2
     assert Study.objects.count() == 2
 
     public_study.is_suppressed = True
@@ -114,6 +120,7 @@ def test_suppressed_study_manager_methods():
     public_study.save()
     private_study.save()
     assert Study.public_objects.count() == 0
+    assert Study.objects_not_suppressed.count() == 0
     assert Study.objects.count() == 2
 
 
@@ -129,7 +136,39 @@ def test_suppressed_study_propagates_to_analyses(raw_read_run):
     assert public_analysis.study.is_suppressed
 
     assert Analysis.public_objects.count() == 0
+    assert Analysis.objects_not_suppressed.count() == 0
     assert Analysis.objects.count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_suppressed_objects_are_hidden_from_detail_apis(raw_read_run, ninja_api_client):
+    analysis = create_analysis(is_private=False)
+    run = analysis.run
+    sample = analysis.sample
+    study = analysis.study
+    assembly_accession = "ERZ00000001"
+    Assembly.objects.create(
+        ena_study=analysis.ena_study,
+        sample=sample,
+        reads_study=study,
+        ena_accessions=[assembly_accession],
+    )
+
+    analysis.ena_study.is_suppressed = True
+    analysis.ena_study.save()
+
+    endpoints = [
+        f"/studies/{study.accession}",
+        f"/samples/{sample.first_accession}",
+        f"/runs/{run.first_accession}",
+        f"/assemblies/{assembly_accession}",
+        f"/analyses/{analysis.accession}",
+        f"/analyses/{analysis.accession}/annotations",
+        f"/analyses/{analysis.accession}/annotations/pfams",
+    ]
+
+    for endpoint in endpoints:
+        assert ninja_api_client.get(endpoint).status_code == 404
 
 
 @pytest.mark.django_db(transaction=True)
@@ -182,6 +221,12 @@ def test_superuser_can_list_private_studies(
     data = response.json()
     assert data["count"] == 1
     assert data["items"][0]["accession"] == webin_private_study.accession
+
+    webin_private_study.is_suppressed = True
+    webin_private_study.save()
+    response = ninja_api_client.get("/my-data/studies/", user=admin_user)
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
 
 
 @pytest.mark.django_db

--- a/ena/models.py
+++ b/ena/models.py
@@ -3,9 +3,11 @@ import logging
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.db import models
-from django.db.models import Model, QuerySet
+from django.db.models import Model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+
+from emgapiv2.model_manager_mixins import SuppressionFilterManagerMixin
 
 # Some models that mirror ENA objects, like Study, Sample, Run etc
 
@@ -14,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 
 class ENAModel(models.Model):
-
     accession = models.CharField(primary_key=True, max_length=20)
     fetched_at = models.DateTimeField(auto_now=True)
     additional_accessions = models.JSONField(default=list, blank=True)
@@ -91,6 +92,9 @@ class StudyManager(models.Manager):
             return obj, True
 
 
+class NotSuppressedStudyManager(SuppressionFilterManagerMixin, StudyManager): ...
+
+
 class Study(ENAModel):
     title = models.TextField()
 
@@ -106,6 +110,7 @@ class Study(ENAModel):
         verbose_name_plural = "studies"
 
     objects: StudyManager = StudyManager()
+    objects_not_suppressed: NotSuppressedStudyManager = NotSuppressedStudyManager()
 
     def __str__(self):
         return self.accession
@@ -148,35 +153,24 @@ def on_ena_study_saved_update_derived_suppression_and_privacy_states(
                         #  we want to avoid circular imports, and because Analysis works slightly differently
                         #  but is caught by this.
 
-                        related_qs: QuerySet = related_model.objects.get_queryset()
-
-                        related_objects_to_update_status_of = related_qs.filter(
-                            ena_study=instance
-                        ).exclude(
-                            **{
-                                field_to_propagate: getattr(
-                                    instance, field_to_propagate
-                                )
-                            }  # optimisation so only select derived objects that are not already up to date
+                        # `objects` is intentionally unfiltered. Visibility-aware
+                        # reads use `objects_not_suppressed` or `public_objects`.
+                        value_to_propagate = getattr(instance, field_to_propagate)
+                        related_objects_to_update_status_of = (
+                            related_model.objects.filter(ena_study=instance).exclude(
+                                **{field_to_propagate: value_to_propagate}
+                            )
                         )
-                        if related_objects_to_update_status_of.exists():
+                        updated_count = related_objects_to_update_status_of.update(
+                            **{field_to_propagate: value_to_propagate}
+                        )
+                        if updated_count:
                             logger.info(
                                 f"Will update {field_to_propagate} state of "
-                                f"{related_objects_to_update_status_of.count()} "
+                                f"{updated_count} "
                                 f"{related_model._meta.app_label}.{related_model._meta.verbose_name_plural} "
-                                f"to {field_to_propagate}={getattr(instance, field_to_propagate)} "
+                                f"to {field_to_propagate}={value_to_propagate} "
                                 f"via {instance.accession}."
-                            )
-                            for related_object in related_objects_to_update_status_of:
-                                setattr(
-                                    related_object,
-                                    field_to_propagate,
-                                    getattr(instance, field_to_propagate),
-                                )
-
-                            related_qs.bulk_update(
-                                related_objects_to_update_status_of,
-                                [field_to_propagate],
                             )
 
 

--- a/ena/tests.py
+++ b/ena/tests.py
@@ -1,14 +1,37 @@
 import re
 
 import pytest
+from django.apps import apps
 from django.core.management import call_command
 
 import analyses.models
 import ena.models
 
 
+def test_models_with_is_suppressed_have_explicit_manager():
+    suppressed_models = [
+        model
+        for model in apps.get_models()
+        if any(field.name == "is_suppressed" for field in model._meta.fields)
+    ]
+
+    assert suppressed_models
+    for model in suppressed_models:
+        assert hasattr(model, "objects_not_suppressed")
+        assert model._default_manager.name == "objects"
+
+
 @pytest.mark.django_db(transaction=True)
 def test_ena_suppression_and_privacy_propagation(mgnify_assemblies, raw_read_analyses):
+    models_with_suppression_managers = (
+        ena.models.Study,
+        analyses.models.Study,
+        analyses.models.Sample,
+        analyses.models.Run,
+        analyses.models.Analysis,
+        analyses.models.Assembly,
+    )
+
     assert analyses.models.Study.objects.count() == 1
 
     assert ena.models.Study.objects.count() == 1
@@ -20,6 +43,10 @@ def test_ena_suppression_and_privacy_propagation(mgnify_assemblies, raw_read_ana
     assert not analyses.models.Run.objects.filter(is_suppressed=True).exists()
     assert not analyses.models.Analysis.objects.filter(is_suppressed=True).exists()
     assert not analyses.models.Assembly.objects.filter(is_suppressed=True).exists()
+    assert all(
+        model.objects_not_suppressed.exists()
+        for model in models_with_suppression_managers
+    )
 
     ena_study.is_suppressed = True
     ena_study.save()
@@ -30,6 +57,14 @@ def test_ena_suppression_and_privacy_propagation(mgnify_assemblies, raw_read_ana
     assert analyses.models.Run.objects.filter(is_suppressed=True).exists()
     assert analyses.models.Analysis.objects.filter(is_suppressed=True).exists()
     assert analyses.models.Assembly.objects.filter(is_suppressed=True).exists()
+    assert all(
+        model.objects.filter(is_suppressed=True).exists()
+        for model in models_with_suppression_managers
+    )
+    assert all(
+        not model.objects_not_suppressed.exists()
+        for model in models_with_suppression_managers
+    )
 
     assert not analyses.models.Study.objects.filter(is_suppressed=False).exists()
     assert not analyses.models.Sample.objects.filter(is_suppressed=False).exists()
@@ -45,6 +80,10 @@ def test_ena_suppression_and_privacy_propagation(mgnify_assemblies, raw_read_ana
     assert not analyses.models.Run.objects.filter(is_suppressed=True).exists()
     assert not analyses.models.Analysis.objects.filter(is_suppressed=True).exists()
     assert not analyses.models.Assembly.objects.filter(is_suppressed=True).exists()
+    assert all(
+        model.objects_not_suppressed.exists()
+        for model in models_with_suppression_managers
+    )
 
     # everything should have been public so far
     assert analyses.models.Study.objects.count() == 1


### PR DESCRIPTION
This PR:
* fixes bug where some suppressed objects (e.g. Analyses) were not excluded form API endpoints because of the manager mixin querysets not cooperating
* refactors the suppression managers a bit


---

#### Checklist
- The tests are passing on Github Actions (checked automatically)
- The test coverage is at least as good as before (checked automatically)
- Any model changes are reflected by migrations (checked automatically)
- [x] `pre-commit` was installed on my dev machine (`pre-commit install`) and I didn't "push anyway"
- [x] The command `task make-dev-data` still works
- [x] The local docker-compose dev environment still works (`task run`)
- [x] Any new prefect flows activate Django before importing any models (`from activate_django_first import EMG_CONFIG`)
- [x] The code style guide in `README.md` has been followed
